### PR TITLE
add pod rule for controler role

### DIFF
--- a/chart/brigade/templates/controller-role.yaml
+++ b/chart/brigade/templates/controller-role.yaml
@@ -24,6 +24,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding
 apiVersion: {{ template "brigade.rbac.version" }}


### PR DESCRIPTION
### why this pr:
controller need rule to create/list ... pods resource, which  is missed in controller-role.yaml