### PR TITLE
add support for gcp auth in brig command

### DIFF
--- a/brigade-client/cmd/brig/commands/app.go
+++ b/brigade-client/cmd/brig/commands/app.go
@@ -4,6 +4,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	// Kube client doesn't support all auth providers by default.
+	// this ensures we include all backends supported by the client.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const mainUsage = `Interact with the Brigade cluster service.

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,23 @@
-hash: 51d03224caaad76c14999c98f53d5ffbafbf0a7060723c1e17cbede59aa9ff35
-updated: 2017-10-23T20:41:57.416167-07:00
+hash: cf0d832c74cb368cc00a866ffe8338b32136bd83f99e80c8f801e00e056c21e1
+updated: 2017-10-30T17:43:24.243392428-07:00
 imports:
+- name: cloud.google.com/go
+  version: eaddaf6dd7ee35fd3c2420c8d27478db176b0485
+  subpackages:
+  - compute/metadata
+- name: github.com/Azure/go-autorest
+  version: 58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d
+  subpackages:
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/date
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
   version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
@@ -120,7 +133,10 @@ imports:
 - name: golang.org/x/oauth2
   version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
+  - google
   - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
@@ -291,9 +307,14 @@ imports:
   - pkg/util
   - pkg/util/parsers
   - pkg/version
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/azure
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
   - rest
   - rest/watch
   - testing
+  - third_party/forked/golang/template
   - tools/auth
   - tools/cache
   - tools/clientcmd
@@ -306,5 +327,6 @@ imports:
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/jsonpath
   - util/workqueue
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,8 @@ package: github.com/Azure/brigade
 import:
 - package: k8s.io/client-go
   version: 4.0.0
+  subpackages:
+  - plugin/pkg/client/auth
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/apis/meta/v1
@@ -16,3 +18,7 @@ import:
 - package: github.com/gosuri/uitable
 - package: github.com/spf13/cobra
 - package: gopkg.in/yaml.v2
+- package: cloud.google.com/go
+  version: ^0.15.0
+  subpackages:
+  - compute/metadata


### PR DESCRIPTION
The `client-go` package doesn't directly import the GCP auth backend. This PR adds an import to the brig command to use all the client-go supported providers.

Without these changes you would get an message saying  `Error: No Auth Provider found for name "gcp"`
