### PR TITLE
fix(worker): disable shared storage by default

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -79,7 +79,7 @@ export class JobCache {
  * Changes to this object only impact the job, not the entire build.
  */
 export class JobStorage {
-  public enabled: boolean = true
+  public enabled: boolean = false
   private _path: string = brigadeStoragePath
   public get path(): string { return this._path }
 }

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -20,7 +20,7 @@ describe("job", function() {
       it("correctly sets default values", function(){
         let c = new JobStorage()
         assert.equal(c.path, brigadeStoragePath, "Dir is " + brigadeStoragePath)
-        assert.isTrue(c.enabled, "enabled by default")
+        assert.isFalse(c.enabled, "disabled by default")
       })
     })
   })
@@ -68,8 +68,8 @@ describe("job", function() {
       })
     })
     describe("#storage", function() {
-      it("is enabled by default", function() {
-        assert.isTrue(j.storage.enabled)
+      it("is disabled by default", function() {
+        assert.isFalse(j.storage.enabled)
       })
     })
   })

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -185,6 +185,7 @@ describe("k8s", function() {
       context("when cache is enabled", function() {
         beforeEach(function() {
           j.cache.enabled = true
+          j.storage.enabled = true
         })
         it("configures volumes", function() {
           let jr = new k8s.JobRunner(j, e, p)

--- a/docs/topics/examples/brigade-15.js
+++ b/docs/topics/examples/brigade-15.js
@@ -6,5 +6,9 @@ events.on("exec", (e, p) => {
   var two = new Job("two", "alpine:3.4", ["echo world >> " + dest])
   var three = new Job("three", "alpine:3.4", ["cat " + dest])
 
+  one.storage.enabled = true
+  two.storage.enabled = true
+  three.storage.enabled = true
+
   Group.runEach([one, two, three])
 })

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -216,9 +216,9 @@ A `JobHost` object provides preferences for the host upon which the job is execu
 
 ### The `JobStorage` class
 
-- `enabled: boolean`: If set to `false`, the Job will not mount the build storage.
-  (Unlike job caches, setting this to false will not alter whether or not the storage
-  is allocated)
+- `enabled: boolean`: If set to `true `, the Job will mount the build storage.
+   Build storage exposes a mounted volume at `/mnt/brigade/share` with storage that
+   can be shared across jobs.
 - `path: string`: The read-only path to the shared storage from within the container.
 
 ### The `KubernetesConfig` class

--- a/docs/topics/scripting.md
+++ b/docs/topics/scripting.md
@@ -938,7 +938,7 @@ built-in shared directories.
 Each build gets its own shared storage. This is a file path that can be accessed by every
 job during the build, but which does not survive after the build has completed.
 
-Storage is always mounted to `/mnt/brigade/share` on each job's container.
+When enabled, storage is mounted to `/mnt/brigade/share` on each job's container.
 
 ```javascript
 const { events, Job, Group } = require("brigadier")
@@ -949,9 +949,14 @@ events.on("exec", (e, p) => {
   var two = new Job("two", "alpine:3.4", ["echo world >> " + dest])
   var three = new Job("three", "alpine:3.4", ["cat " + dest])
 
+  one.storage.enabled = true
+  two.storage.enabled = true
+  three.storage.enabled = true
+
   Group.runEach([one, two, three])
 })
 ```
+[brigade-16.js](examples/brigade-16.js)
 
 In the script above, jobs `one` and `two` should each write a line to the file
 `hello.txt`, which is stored in the shared `/mnt/brigade/share` directory. Since this
@@ -968,7 +973,7 @@ world
 
 That is exactly what we would expect to see.
 
-Importantly, shared storage space is listed to 50 megabytes of storage per build. This can
+Importantly, shared storage space is limited to 50 megabytes of storage per build. This can
 be overridden in the project configuration.
 
 > Note: Shared storage is dependent on the underlying Kubernetes cluster. Some Kubernetes


### PR DESCRIPTION
Leaving this enabled adds a pretty serious performance hit on at least
some systems. And it is not typically used by containers out of the box.
That is, most of the time it is used, usage is already manually
configured by the script author. So it makes sense to go with
performance as the default metric.