### PR TITLE
fix(chart): set API svc default type to ClusterIP

### DIFF
--- a/chart/brigade/values.yaml
+++ b/chart/brigade/values.yaml
@@ -14,7 +14,7 @@ api:
   tag: latest
   service:
     name: brigade-api
-    type: LoadBalancer
+    type: ClusterIP
     externalPort: 7745
     internalPort: 7745
 


### PR DESCRIPTION
This prevents the (insecure) API server from being exposed to the
world by default.