### PR TITLE
fix(brig): read the file

### DIFF
--- a/brigade-client/cmd/brig/commands/run.go
+++ b/brigade-client/cmd/brig/commands/run.go
@@ -66,7 +66,12 @@ var run = &cobra.Command{
 		proj := args[0]
 
 		var script []byte
-		var err error
+		if len(runFile) > 0 {
+			var err error
+			if script, err = ioutil.ReadFile(runFile); err != nil {
+				return err
+			}
+		}
 
 		a, err := newScriptRunner()
 		if err != nil {


### PR DESCRIPTION
During some merges, we lost the proper handling of the -f flag.
Fixed.