### PR TITLE
ref(chart): make chart smart about versions

### DIFF
--- a/chart/brigade/Chart.yaml
+++ b/chart/brigade/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: Brigade provides event-driven scripting of Kubernetes pipelines.
 name: brigade
 version: 0.3.0
+# Note that we use appVersion to get images, so make sure this is correct.
+appVersion: v0.3.0

--- a/chart/brigade/templates/api-deployment.yaml
+++ b/chart/brigade/templates/api-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.api.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -17,7 +18,7 @@ spec:
       serviceAccountName: {{ template "brigade.api.fullname" . }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.api.registry }}/{{ .Values.api.name }}:{{ .Values.api.tag }}"
+        image: "{{ .Values.api.registry }}/{{ .Values.api.name }}:{{ default .Chart.AppVersion .Values.api.tag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.api.pullPolicy }}
         ports:
         - containerPort: {{ .Values.api.service.internalPort }}
@@ -36,3 +37,4 @@ spec:
                 fieldPath: metadata.namespace
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
+{{ end }}

--- a/chart/brigade/templates/api-service.yaml
+++ b/chart/brigade/templates/api-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.api.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     name: {{ .Values.api.service.name }}
   selector:
     app: {{ template "brigade.api.fullname" . }}
+{{ end }}

--- a/chart/brigade/templates/controller-deployment.yaml
+++ b/chart/brigade/templates/controller-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: {{ $fullname }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.controller.registry }}/{{ .Values.controller.name }}:{{ .Values.controller.tag }}"
+        image: "{{ .Values.controller.registry }}/{{ .Values.controller.name }}:{{ default .Chart.AppVersion .Values.controller.tag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.controller.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
@@ -28,7 +28,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: BRIGADE_WORKER_IMAGE
-            value: "{{ .Values.worker.registry }}/{{ .Values.worker.name }}:{{ .Values.worker.tag }}"
+            value: "{{ .Values.worker.registry }}/{{ .Values.worker.name }}:{{ default .Chart.AppVersion .Values.worker.tag }}"
           - name: BRIGADE_WORKER_PULL_POLICY
             value: {{ default "IfNotPresent" .Values.worker.pullPolicy }}
       {{ if .Values.privateRegistry }}imagePullSecrets:

--- a/chart/brigade/templates/gateway-deployment.yaml
+++ b/chart/brigade/templates/gateway-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.gw.enabled }}
 {{ $fullname := include "brigade.gw.fullname" . }}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -20,8 +21,8 @@ spec:
       serviceAccountName: {{ $fullname }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        image: "{{ .Values.gw.registry }}/{{ .Values.gw.name }}:{{ default .Chart.AppVersion .Values.gw.tag }}"
+        imagePullPolicy: {{ default "IfNotPresent" .Values.gw.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
@@ -39,3 +40,4 @@ spec:
                 fieldPath: metadata.namespace
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
+{{ end }}

--- a/chart/brigade/templates/gateway-service.yaml
+++ b/chart/brigade/templates/gateway-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.gw.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     app: {{ template "brigade.fullname" . }}
     role: gateway
+{{ end }}

--- a/chart/brigade/values.yaml
+++ b/chart/brigade/values.yaml
@@ -1,32 +1,72 @@
-image:
-  registry: deis
-  name: brigade-gateway
-  tag: latest
-  #pullPolicy: IfNotPresent
-controller:
-  registry: deis
-  name: brigade-controller
-  tag: latest
-  #pullPolicy: IfNotPresent
-api:
-  registry: deis
-  name: brigade-api
-  tag: latest
-  service:
-    name: brigade-api
-    type: ClusterIP
-    externalPort: 7745
-    internalPort: 7745
-worker:
-  registry: deis
-  name: brigade-worker
-  tag: latest
-  #pullPolicy: IfNotPresent
+# This is the main configuration file for the Brigade chart.
+# To override values here, specify them in your own YAML file, and override
+# during install or upgrade:
+#
+#    $ helm install -n brigade -f myValues.yaml brigade/brigade
+#
+# By default, the chart will install without RBAC. To install with
+# RBAC, set `rbac.enabled` to `true`.
+#
+# To disable the GitHub gateway, set `gw.enabled` to `false`. This will mean
+# that no GitHub hooks will work, though scripts will still be able to mount
+# GitHub projects based on the Project configuration.
+#
+# Advanced Configuration
+#
+# Developers may wish to override the location of Docker images. For each
+# deployment, `registry` controls the image registry, and `name` controls
+# the image name. If unspecified, the Chart.yaml's appVersion field will be
+# used to pull the tag. If you override the `tag` value, that version will
+# be used instead.
+
 
 # If enabled, roles, role bindings will be turned on.
 rbac:
   enabled: false
 
+# controller is the main event processor in Brigade.
+controller:
+  registry: deis
+  name: brigade-controller
+  # tag should only be specified if you want to override Chart.appVersion
+  # The default tag is the value of .Chart.AppVersion
+  #tag:
+  #pullPolicy: IfNotPresent
+
+# api is the API server. It is technically not needed for the operation of the
+# Brigade controller, but it is used by tools to learn about the state of the
+# cluster.
+#
+# If you disable it, Brigade will still process events, but extra tooling (like
+# brig) may not be able to learn about it.
+api:
+  enabled: true
+  registry: deis
+  name: brigade-api
+  # tag:
+  service:
+    name: brigade-api
+    type: ClusterIP
+    externalPort: 7745
+    internalPort: 7745
+
+# worker is the JavaScript worker. These are created on demand by the controller.
+worker:
+  registry: deis
+  name: brigade-worker
+  #tag:
+  #pullPolicy: IfNotPresent
+
+# gw is the GitHub gateway.
+gw:
+  enabled: true
+  registry: deis
+  name: brigade-gateway
+  #tag:
+  #pullPolicy: IfNotPresent
+
+# The service is for the Brigade gateway. If you do not want to have Brigade
+# listening for incomming GitHub requests, disable this.
 service:
   name: brigade-service
   type: LoadBalancer


### PR DESCRIPTION
This is part of a bigger effort to make version handling in Brigade
better.

This changes the charts to use the `appVersion` field in `Chart.yaml` to
set the image tag. The `tag` field still exists for overrides, but it
simplifies the chart to assume that each component of the chart should
use the master version number to pull its tag.

Along the way, I improved documentation, and made it trivially possible
to disable API and Gateway.