### PR TITLE
Make runEach return JobResult of all Jobs

### DIFF
--- a/brigade-worker/src/group.ts
+++ b/brigade-worker/src/group.ts
@@ -27,7 +27,7 @@ export class Group {
    * This runs a series of jobs in order, blocking on each until it completes.
    * It is equivalent to `(new Group(jobs)).runEach()`
    */
-  public static runEach(jobs: jobImpl.Job[]): Promise<jobImpl.Result> {
+  public static runEach(jobs: jobImpl.Job[]): Promise<jobImpl.Result[]> {
     let g = new Group(jobs)
     return g.runEach()
   }
@@ -53,10 +53,15 @@ export class Group {
   /**
    * runEach runs each job in order and waits for every one to finish.
    */
-  public runEach(): Promise<jobImpl.Result> {
-    return this.jobs.reduce((p: Promise<jobImpl.Result>, j: jobImpl.Job) => {
-      return p.then(() => j.run())
-    }, Promise.resolve(new EmptyResult()))
+  public runEach(): Promise<jobImpl.Result[]> {
+    return this.jobs.reduce((promise: Promise<jobImpl.Result[]>, job: jobImpl.Job) => {
+      return promise.then((results: jobImpl.Result[]) => {
+        return job.run().then(jobResult => {
+          results.push(jobResult);
+          return results;
+        })
+      });
+    }, Promise.resolve([]));
   }
   /**
    * runAll runs all jobs in parallel and waits for them all to finish.

--- a/brigade-worker/test/brigadier.ts
+++ b/brigade-worker/test/brigadier.ts
@@ -55,8 +55,10 @@ describe("brigadier", function() {
         // 1 and 2 would finish before 3.
         j3.delay = 50
         g.add(j1, j2, j3)
-        g.runEach().then((rez: jobImpl.Result) => {
-          assert.equal(rez.toString(), j3.name)
+        g.runEach().then((rez: jobImpl.Result[]) => {
+          assert.equal(rez[0], j1.name)
+          assert.equal(rez[1], j2.name)
+          assert.equal(rez[2], j3.name)
           done()
         })
       })

--- a/brigade-worker/test/group.ts
+++ b/brigade-worker/test/group.ts
@@ -31,8 +31,10 @@ describe("group", function() {
         // 1 and 2 would finish before 3.
         j3.delay = 50
         g.add(j1, j2, j3)
-        g.runEach().then((rez: jobImpl.Result) => {
-          assert.equal(rez.toString(), j3.name)
+        g.runEach().then((rez: jobImpl.Result[]) => {
+          assert.equal(rez[0], j1.name)
+          assert.equal(rez[1], j2.name)
+          assert.equal(rez[2], j3.name)
           done()
         })
       })
@@ -43,7 +45,7 @@ describe("group", function() {
           j2.fail = true
           let j3 = new mock.MockJob("third")
           g.add(j1, j2, j3)
-          g.runEach().then((rez: jobImpl.Result) => {
+          g.runEach().then((rez: jobImpl.Result[]) => {
             done("expected error on job 2")
           }).catch((msg) => {
             assert.equal(msg, "Failed")
@@ -87,8 +89,10 @@ describe("group", function() {
         // This ensures that if the jobs were not executed in sequence,
         // 1 and 2 would finish before 3.
         j3.delay = 5
-        group.Group.runEach([j1, j2, j3]).then((rez: jobImpl.Result) => {
-          assert.equal(rez.toString(), j3.name)
+        group.Group.runEach([j1, j2, j3]).then((rez: jobImpl.Result[]) => {
+          assert.equal(rez[0], j1.name)
+          assert.equal(rez[1], j2.name)
+          assert.equal(rez[2], j3.name)
           done()
         })
       })

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -108,10 +108,10 @@ all jobs are done and then returns the collected results.
 This is useful for running a batch of jobs in parallel, but waiting until they are
 complete before continuing with another operation.
 
-#### The static `runEach(Job[]): Promise<Result>` method
+#### The static `runEach(Job[]): Promise<Result[]>` method
 
 This runs each of the given jobs in sequence, blocking on each job until it
-is complete. The Promise will return the output of the last job in the sequence.
+is complete. The Promise will return the collected results.
 
 #### The `new Group(Job[]): Group` constructor
 
@@ -134,8 +134,8 @@ Functionally, this is equivalent to the static `runAll` method.
 
 #### The `runEach` method
 
-Runs each of the jobs in sequence (synchronously). When the Promise resolves, it
-will contain the last Job's result.
+Runs each of the jobs in sequence (synchronously). When the Promise resolves, it will
+wrap all of the results.
 
 Functionally, this is equivalent to the static `runEach` method.
 


### PR DESCRIPTION
Changed the method to return a list of results for the job. 
Also rewrote the tests to reflect the change. 

I made a simple implementation. I hope it is what was wanted.

This should resolve #100 