### PR TITLE
fix(api,controller,worker): use ULID for ID

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -23,7 +23,7 @@ func TestController(t *testing.T) {
 	})
 	config := &Config{
 		Namespace:        v1.NamespaceDefault,
-		WorkerImage:      "deis/brgiade-worker:latest",
+		WorkerImage:      "deis/brigade-worker:latest",
 		WorkerPullPolicy: string(v1.PullIfNotPresent),
 	}
 	controller := NewController(client, config)
@@ -36,6 +36,7 @@ func TestController(t *testing.T) {
 				"heritage":  "brigade",
 				"component": "build",
 				"project":   "ahab",
+				"build":     "queequeg",
 			},
 		},
 	}
@@ -86,8 +87,8 @@ func TestController(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 6 {
-		t.Errorf("expected 6 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 7 {
+		t.Errorf("expected 7 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -139,6 +140,7 @@ func TestController_WithScript(t *testing.T) {
 				"heritage":  "brigade",
 				"component": "build",
 				"project":   "ahab",
+				"build":     "queequeg",
 			},
 		},
 		Data: map[string][]byte{
@@ -192,8 +194,8 @@ func TestController_WithScript(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 6 {
-		t.Errorf("expected 6 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 7 {
+		t.Errorf("expected 7 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -231,6 +233,7 @@ func TestController_NoSidecar(t *testing.T) {
 				"heritage":  "brigade",
 				"component": "build",
 				"project":   "ahab",
+				"build":     "queequeg",
 			},
 		},
 	}
@@ -265,8 +268,8 @@ func TestController_NoSidecar(t *testing.T) {
 	}
 
 	c := pod.Spec.Containers[0]
-	if envlen := len(c.Env); envlen != 6 {
-		t.Errorf("expected 6 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 7 {
+		t.Errorf("expected 7 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -92,7 +92,7 @@ func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
 				envvar("project_id"),
 				envvar("event_type"),
 				envvar("event_provider"),
-				envvar("build_id"),
+				envvar("build_name"),
 				envvar("commit"),
 				{
 					Name: "BRIGADE_PROJECT_NAMESPACE",

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -10,7 +10,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ErrNoBuildID indicates that a secret does not have a build ID attached.
+var ErrNoBuildID = errors.New("no build ID on secret")
+
 func (c *Controller) syncSecret(secret *v1.Secret) error {
+	// If a secret does not have a build ID then it cannot be tracked through
+	// the system. A build ID should be a ULID.
+	if bid, ok := secret.Labels["build"]; !ok || len(bid) == 0 {
+		// Alternately, we could add a build ID and then re-save the secret.
+		log.Printf("syncSecret: secret %s/%s has no build ID. Discarding.", secret.Namespace, secret.Name)
+		return ErrNoBuildID
+	}
 	data := secret.Data
 
 	log.Printf("EventHandler: type=%s provider=%s commit=%s", data["event_type"], data["event_provider"], data["commit"])
@@ -89,6 +99,10 @@ func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
 					ValueFrom: &v1.EnvVarSource{
 						FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
 					},
+				},
+				{
+					Name:  "BRIGADE_BUILD",
+					Value: secret.Labels["build"],
 				},
 			},
 		}},

--- a/brigade-worker/src/app.ts
+++ b/brigade-worker/src/app.ts
@@ -185,15 +185,5 @@ export class App {
 
     brigadier.fire(errorEvent, this.proj)
   }
-
-  /**
-   * Generate a random build ID.
-   *
-   * DEPRECATED: Use a ULID for unique ID, and worker ID to identify the parent
-   * worker.
-   */
-  public static generateBuildID(commit: string): string {
-    return `brigade-worker-${ ulid() }-${ commit.substring(0, 8) }`
-  }
 }
 

--- a/brigade-worker/src/events.ts
+++ b/brigade-worker/src/events.ts
@@ -39,6 +39,10 @@ export class BrigadeEvent {
      */
     buildID: string;
     /**
+     * workerID is the ID of the worker responsible for handling this event.
+     */
+    workerID: string;
+    /**
      * type is the event type ("push", "pull_request")
      */
     type: string;

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -13,6 +13,8 @@
  * - `BRIGADE_PROJECT_NAMESPACE`: For Kubernetes, this is the Kubernetes namespace in
  *   which new jobs should be created. The Brigade worker must have write access to
  *   this namespace.
+ * - `BRIGADE_BUILD`: The ULID for the build. This is unique.
+ * - `BRIGADE_BUILD_ID`: This is actually the ID of the worker.
  *
  * Also, the Brigade script must be written to `brigade.js`.
  */
@@ -22,6 +24,8 @@
 
 import * as fs from "fs"
 import * as process from "process"
+
+import * as ulid from "ulid"
 
 import * as events from "./events"
 import * as k8s from "./k8s"
@@ -34,8 +38,10 @@ import "./brigade"
 let projectID: string = process.env.BRIGADE_PROJECT_ID
 let projectNamespace: string = process.env.BRIGADE_PROJECT_NAMESPACE
 let commit = process.env.BRIGADE_COMMIT || "master"
+let defaultULID = ulid()
 let e: events.BrigadeEvent = {
-    buildID: process.env.BRIGADE_BUILD_ID || App.generateBuildID(commit),
+    buildID: process.env.BRIGADE_BUILD || defaultULID,
+    workerID: process.env.BRIGADE_BUILD_ID || `unknown-${ defaultULID }`,
     type: process.env.BRIGADE_EVENT_TYPE || "ping",
     provider: process.env.BRIGADE_EVENT_PROVIDER || "unknown",
     commit: commit

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -14,7 +14,7 @@
  *   which new jobs should be created. The Brigade worker must have write access to
  *   this namespace.
  * - `BRIGADE_BUILD`: The ULID for the build. This is unique.
- * - `BRIGADE_BUILD_ID`: This is actually the ID of the worker.
+ * - `BRIGADE_BUILD_NAME`: This is actually the ID of the worker.
  *
  * Also, the Brigade script must be written to `brigade.js`.
  */
@@ -41,7 +41,7 @@ let commit = process.env.BRIGADE_COMMIT || "master"
 let defaultULID = ulid()
 let e: events.BrigadeEvent = {
     buildID: process.env.BRIGADE_BUILD || defaultULID,
-    workerID: process.env.BRIGADE_BUILD_ID || `unknown-${ defaultULID }`,
+    workerID: process.env.BRIGADE_BUILD_NAME || `unknown-${ defaultULID }`,
     type: process.env.BRIGADE_EVENT_TYPE || "ping",
     provider: process.env.BRIGADE_EVENT_PROVIDER || "unknown",
     commit: commit

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -38,13 +38,15 @@ class K8sResult implements jobs.Result {
 export class BuildStorage {
   proj: Project
   name: string
+  build: string
 
   /**
    * create initializes a new PVC for storing data.
    */
-  public create(buildID: string, project: Project, size: string): Promise<string> {
+  public create(e: BrigadeEvent, project: Project, size: string): Promise<string> {
     this.proj = project
-    this.name = buildID
+    this.name = e.workerID.toLowerCase()
+    this.build = e.buildID
     let pvc = this.buildPVC(size)
     console.log(`Creating PVC named ${ this.name }`)
     return defaultClient.createNamespacedPersistentVolumeClaim(this.proj.kubernetes.namespace, pvc)
@@ -69,7 +71,9 @@ export class BuildStorage {
     s.metadata.labels = {
       "heritage": "brigade",
       "component": "buildStorage",
-      "project": this.proj.id
+      "project": this.proj.id,
+      "worker": this.name,
+      "build": this.build,
     }
 
     s.spec = new kubernetes.V1PersistentVolumeClaimSpec()
@@ -129,11 +133,15 @@ export class JobRunner implements jobs.JobRunner {
     this.runner.metadata.labels.jobname = job.name
     this.runner.metadata.labels.project = project.id
     this.runner.metadata.labels.commit = commit
+    this.runner.metadata.labels.worker = e.workerID
+    this.runner.metadata.labels.build = e.buildID
 
     this.secret.metadata.labels.jobname = job.name
     this.secret.metadata.labels.project = project.id
     this.secret.metadata.labels.commit = commit
     this.secret.metadata.labels.expires = String(expiresAt)
+    this.secret.metadata.labels.worker = e.workerID
+    this.secret.metadata.labels.build = e.buildID
 
     let envVars: kubernetes.V1EnvVar[] = []
     for (let key in job.env) {

--- a/brigade-worker/test/app.ts
+++ b/brigade-worker/test/app.ts
@@ -24,11 +24,6 @@ describe("app", function() {
       // Disable this so we can run tests without panics.
       a.exitOnError = false
     })
-    describe("App.generateBuildID", function() {
-      // brigade-worker-01BR5VRVP06Q0BASBVB1WYK7X1-01234567
-      let commit = "01234567890"
-      assert.match(app.App.generateBuildID(commit), /brigade-worker-[A-Z0-9]{26}-01234567/)
-    })
     describe("#run", function() {
       it("runs an event handler to completion", function(done) {
         let e = mock.mockEvent()

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -76,6 +76,12 @@ describe("k8s", function() {
         assert.equal(jr.runner.metadata.labels.commit, e.commit)
         assert.equal(jr.secret.metadata.labels.commit, e.commit)
 
+        assert.equal(jr.runner.metadata.labels.worker, e.workerID)
+        assert.equal(jr.secret.metadata.labels.worker, e.workerID)
+
+        assert.equal(jr.runner.metadata.labels.build, e.buildID)
+        assert.equal(jr.secret.metadata.labels.build, e.buildID)
+
         assert.isNotNull(jr.runner.spec.containers[0].command)
         assert.property(jr.secret.data, "main.sh")
       })

--- a/brigade-worker/test/mock.ts
+++ b/brigade-worker/test/mock.ts
@@ -23,7 +23,8 @@ export function mockProject(): Project {
 
 export function mockEvent() {
   return {
-    buildID: "test-1234567890abcdef-12345678",
+    buildID: "1234567890abcdef",
+    workerID: "test-1234567890abcdef-12345678",
     type: "push",
     provider: "github",
     commit: "c0ffee",
@@ -65,8 +66,8 @@ export class MockJob extends Job {
 }
 
 export class MockBuildStorage {
-  public create(id: string, project: Project, size?: string): Promise<string> {
-    return Promise.resolve(id)
+  public create(e: BrigadeEvent, project: Project, size?: string): Promise<string> {
+    return Promise.resolve(e.workerID)
   }
   public destroy(): Promise<boolean> {
     return Promise.resolve(true)

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -66,7 +66,7 @@ func (s *store) CreateBuild(build *brigade.Build) error {
 			"event_type":     build.Type,
 			"event_provider": build.Provider,
 			"commit":         build.Commit,
-			"build_id":       buildName,
+			"build_name":     buildName,
 		},
 	}
 

--- a/pkg/storage/kube/job.go
+++ b/pkg/storage/kube/job.go
@@ -33,7 +33,7 @@ func (s *store) GetJob(id string) (*brigade.Job, error) {
 
 func (s *store) GetBuildJobs(build *brigade.Build) ([]*brigade.Job, error) {
 	// Load the pods that ran as part of this build.
-	lo := meta.ListOptions{LabelSelector: fmt.Sprintf("heritage=brigade,component=job,commit=%s,project=%s", build.Commit, build.ProjectID)}
+	lo := meta.ListOptions{LabelSelector: fmt.Sprintf("heritage=brigade,component=job,build=%s,project=%s", build.ID, build.ProjectID)}
 
 	podList, err := s.client.CoreV1().Pods(s.namespace).List(lo)
 	if err != nil {

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -13,7 +12,7 @@ import (
 
 // GetProjects retrieves all projects from storage.
 func (s *store) GetProjects() ([]*brigade.Project, error) {
-	lo := meta.ListOptions{LabelSelector: fmt.Sprintf("app=brigade,component=project")}
+	lo := meta.ListOptions{LabelSelector: "app=brigade,component=project"}
 	secretList, err := s.client.CoreV1().Secrets(s.namespace).List(lo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There were a few places where instead of using the ULID as an ID, the
system was using project + commit as an ID. That, however, is not
unique. This was resulting in incorrect data being returned by the API
server.

One of the reasons for the above was that job pods were not being
labeled with the ULID (or with the worker ID). So there was no way to
correlated a job with its worker parent or build. So this adds two new
labels on a job pod: worker and build. The build ID is also added to the
PVC for build storage.

Finally, the API server has been fixed to use the build ID instead of
the commit for finding associated jobs.

Closes #121