### PR TITLE
fix(api): show secret names, but not values

### DIFF
--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -2,6 +2,7 @@ package brigade
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -24,7 +25,19 @@ type Project struct {
 	// Github holds information about Github.
 	Github Github `json:"github"`
 	// Secrets is environment variables for brigade.js
-	Secrets map[string]string `json:"-"`
+	Secrets SecretsMap `json:"secrets"`
+}
+
+type SecretsMap map[string]string
+
+const redacted = "REDACTED"
+
+func (s SecretsMap) MarshalJSON() ([]byte, error) {
+	dest := make(map[string]string, len(s))
+	for k := range s {
+		dest[k] = redacted
+	}
+	return json.Marshal(dest)
 }
 
 // ProjectID will encode a project name.

--- a/pkg/brigade/project_test.go
+++ b/pkg/brigade/project_test.go
@@ -36,8 +36,8 @@ func TestProjectSecrets(t *testing.T) {
 	if got.SharedSecret != "" {
 		t.Error("Project.SharedSecret should not be exported")
 	}
-	if got.Secrets != nil {
-		t.Error("Project.Secrets should not be exported")
+	if val, ok := got.Secrets["foo"]; !ok || val != redacted {
+		t.Error("Project.Secrets should not be " + redacted)
 	}
 	if got.Repo.SSHKey != "" {
 		t.Error("Project.Repo.SSHKey should not be exported")


### PR DESCRIPTION
The API server now shows the names of the secrets, but not
their values. This allows user interfaces to show which secrets are
present, but not be able to show their values.

The returned value for secrets is still a map, to accurately reflect the
structure of a secret. But the value is always "REDACTED".