### PR TITLE
fix(chart): fix project chart's missing sidecar value

### DIFF
--- a/chart/brigade-project/templates/secret.yaml
+++ b/chart/brigade-project/templates/secret.yaml
@@ -15,7 +15,7 @@ data:
   repository: {{ .Values.repository | b64enc }}
   sharedSecret: {{ .Values.sharedSecret | b64enc }}
   cloneURL: {{ .Values.cloneURL | b64enc }}
-  vcsSidecar: {{ .Values.vcsSidecar | b64enc }}
+  vcsSidecar: {{ default "" .Values.vcsSidecar | b64enc }}
   secrets: {{ .Values.secrets | toJson | b64enc }}
   {{ if .Values.github.token -}}
   github.token: {{.Values.github.token | b64enc }}


### PR DESCRIPTION
No default value was placed in the sidecar, which cases the base64 enc
operation to fail. Added blank default value.

Closes #131