### PR TITLE
docs(*): switch recommendation to helm repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ architecture.
 The easiest way to install Brigade into your Kubernetes cluster is to install it using Helm.
 
 ```console
-$ git clone https://github.com/Azure/brigade.git
-$ cd brigade
-$ helm install --name brigade ./charts/brigade
+$ helm repo add brigade https://azure.github.io/brigade
+$ helm install -n brigade brigade/brigade
 ```
 
 You will now have Brigade installed.
@@ -49,14 +48,17 @@ To create new projects, use the `brigade-project` Helm chart. While inside the G
 repository cloned above, run these commands:
 
 ```console
-$ helm inspect values ./charts/brigade-project > myvalues.yaml
+$ helm inspect values brigade/brigade-project > myvalues.yaml
 $ # edit myvalues.yaml
-$ helm install --name my-project ./charts/brigade-project -f myvalues.yaml
 ```
 
 When editing `myvalues.yaml`, follow the instructions in that file for configuring
 your new project. Once you have customized that file, you can install the project
 based on your new configuration by passing it with `-f myvalues.yaml`.
+
+```console
+$ helm install --name my-project brigade/brigade-project -f myvalues.yaml
+```
 
 Now creating your first `brigade.js` is as easy as this:
 

--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -81,6 +81,14 @@ $ eval $(minikube docker-env)
 Running `make docker-build docker-push` will push the Brigade images to the Minikube Docker
 daemon.
 
+From here, you can install Brigade into Minikube using the Helm chart:
+
+```
+$ helm install -n brigade ./charts/brigade
+```
+
+Don't forget to also create a project (`$ helm install -n empty-testbed charts/brigade-project`).
+
 ## Running Brigade inside remote Kubernetes
 
 Some developers use a remote Kubernetes instead of minikube.

--- a/docs/topics/install.md
+++ b/docs/topics/install.md
@@ -2,34 +2,47 @@
 
 This guide provides detailed information about installing and configuring the Brigade services.
 
+> Brigade is under highly active development. Day to day, the `master` branch is
+> changing. If you choose to build from source, you may prefer to build off of
+> a tagged release rather than master.
+
 ## Installing the Kubernetes Services
 
 Brigade runs inside of a Kubernetes cluster. This section explains how to install
 into an existing Kubernetes cluster.
 
-### Option 1: Install from GitHub Repository
+### Option 1: Install from the Chart Repository
 
-To install from the GitHub repository, follow these steps:
-
-```console
-$ git clone https://github.com/azure/brigade.git
-$ cd brigade
-$ helm install ./charts/brigade
-```
-
-### Option 2: Install from the Chart Repository
-
-It is also possible to build from the Chart Repository. The repository is only
-updated when a new version is released, and will likely not be as up-to-date as
-the GitHub repository.
+Each time the Brigade team cuts a new release, we update the Helm charts. Installing
+with Helm is the best way to get a working release of Brigade.
 
 ```console
 $ helm repo add brigade https://azure.github.io/brigade
 $ helm install brigade/brigade
 ```
 
+### Option 2: Install from GitHub Repository
+
+If you are developing Brigade, or are interested in testing the latest features
+(at the cost of additional time and energy), you can build Brigade from source.
+
+The `master` branch typically contains newer code than the last release. However,
+the charts will install the last released version.
+
+```console
+$ git clone https://github.com/azure/brigade.git
+$ cd brigade
+$ # optionally check out a tagged release: git checkout v0.5.0
+$ helm install ./charts/brigade
+```
+
 Once you have Brigade installed, you can proceed to [creating a project](projects.md).
 The remainder of this guide covers special configurations of Brigade.
+
+> If you are not working off of a tagged release, you may also have to build
+> custom images. The [Developers Guide](developers.md) explains this in more
+> detail. Otherwise, the images referenced by the chart will be from the last
+> release, and may not have the latest changes.
 
 ### Customizing Installations
 


### PR DESCRIPTION
This changes our recommendation from source build to using the Helm repo
for Brigade install. It should ease the process for first-time users.