### PR TITLE
fix(worker): stop after from firing when no hook was executed.

### DIFF
--- a/brigade-worker/src/app.ts
+++ b/brigade-worker/src/app.ts
@@ -143,7 +143,16 @@ export class App {
           trigger: code == 0 ? "success" : "failure"
         } as events.Cause
       }
-      brigadier.fire(after, this.proj)
+
+      // Only fire an event if the top-level had a match.
+      if (brigadier.events.has(e.type)) {
+        brigadier.fire(after, this.proj)
+      } else {
+        this.afterHasFired = true
+        setImmediate(() => {
+          console.log("no-after: fired")
+        }, 20)
+      }
     })
 
     // Now that we have all the handlers registered, load the project and


### PR DESCRIPTION
This stops the 'after' event from firing in the event that there is no
target event handler for the given event.

There's a little bit of extra clean-up logic to make sure that PVCs and
other things are torn down properly.

Closes #21