### PR TITLE
Use alpine edge to get git@2.15.0

### DIFF
--- a/git-sidecar/Dockerfile
+++ b/git-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:edge
 
 RUN apk update && apk add --no-cache \
     ca-certificates \


### PR DESCRIPTION
Hi there,

At ApiPlatform we want to use Brigade to run some of our tests that require more power then a limit travis instance. 
We have an issue with `git@2.13.5` while executing:

```
+ git fetch origin VCS_REVISION
error: Server does not allow request for unadvertised object VCS_REVISION
```

where VCS_REVISION is a given `sha1` from github servers.

Link to the brigade PR on our repository: https://github.com/api-platform/core/pull/1507

This command does work with `git@2.15.0` which is only available with `alpine:edge` version.