### PR TITLE
feat(api): list projects with latest builds

### DIFF
--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -50,6 +50,7 @@ func main() {
 	rest.GET("/projects", p.List)
 	rest.GET("/project/:id", p.Get)
 	rest.GET("/project/:id/builds", p.Builds)
+	rest.GET("/projects-build", p.ListWithLatestBuild)
 
 	b := server.Build()
 	rest.GET("/build/:id", b.Get)


### PR DESCRIPTION
This adds a new endpoint:

/v1/projects-build

This returns a list of projects together with the latest build for each
project. It is notably heavier processing than /v1/projects. The
returned data structure is also substantially different: It's an array
of project/build pairs represented as a map.

```json
[
  {
    "project": {
      "id": "brigade-635e505c74ad679bb9144d19950504fbe86b136ac3770bcff51ac6",
      "name": "technosophos/brigade-trello",
      "repo": {
        "name": "github.com/technosophos/brigade-trello",
        "cloneURL": "https://github.com/technosophos/brigade-trello.git"
      },
      "kubernetes": {
        "namespace": "default",
        "vcsSidecar": ""
      },
      "github": {},
      "secrets": {
        "SLACK_WEBHOOK": "REDACTED",
        "cosmosKey": "REDACTED",
        "cosmosName": "REDACTED",
        "trelloKey": "REDACTED",
        "trelloModel": "REDACTED",
        "trelloToken": "REDACTED"
      }
    },
    "lastBuild": null
  },
  {
    "project": {
      "id": "brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac",
      "name": "deis/empty-testbed",
      "repo": {
        "name": "github.com/deis/empty-testbed",
        "cloneURL": "https://github.com/deis/empty-testbed.git"
      },
      "kubernetes": {
        "namespace": "default",
        "vcsSidecar": ""
      },
      "github": {},
      "secrets": {
        "SLACK_WEBHOOK": "REDACTED",
        "dbPassword": "REDACTED"
      }
    },
    "lastBuild": {
      "id": "01bz65k7f2cz9z282y38j897tm",
      "project_id": "brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac",
      "type": "exec",
      "provider": "brigade-cli",
      "commit": "master",
      "script": "Y29uc3QgeyBldmVudHMsIEpvYiwgR3JvdXAgfSA9IHJlcXVpcmUoImJyaWdhZGllciIpCgpldmVudHMub24oImV4ZWMiLCAoKSA9PiB7CiAgY29uc29sZS5sb2coIlxuID09PT4gd2VlZWVcbiIpCgogIHZhciBqMSA9IG5ldyBKb2IoImhlbGxvIiwgImFscGluZTozLjYiKQoKICBqMS50YXNrcyA9IFsKICAgICJlY2hvIGhlbGxvIgogIF0KCiAgdmFyIGoyID0gbmV3IEpvYigid29ybGQiLCAiYWxwaW5lOjMuNiIsIFsiZWNobyBoZWxsbzIiXSkKCiAgR3JvdXAucnVuRWFjaChbajEsIGoyXSkKfSkK",
      "worker": {
        "id": "brigade-worker-01bz65k7f2cz9z282y38j897tm-master",
        "build_id": "01bz65k7f2cz9z282y38j897tm",
        "project_id": "brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac",
        "start_time": "2017-11-16T07:36:47-07:00",
        "end_time": "2017-11-16T07:36:57-07:00",
        "exit_code": 0,
        "status": "Succeeded"
      }
    }
  },
  {
    "project": {
      "id": "brigade-cf0858d449971e79083aacddc565450b8bf65a2b9f5d66ea76fdb4",
      "name": "technosophos/twitter-t",
      "repo": {
        "name": "github.com/technosophos/twitter-t",
        "cloneURL": "https://github.com/technosophos/twitter-t.git"
      },
      "kubernetes": {
        "namespace": "default",
        "vcsSidecar": ""
      },
      "github": {},
      "secrets": {
        "ACCESS_SECRET": "REDACTED",
        "ACCESS_TOKEN": "REDACTED",
        "CONSUMER_KEY": "REDACTED",
        "CONSUMER_SECRET": "REDACTED",
        "OWNER": "REDACTED"
      }
    },
    "lastBuild": null
  }
]
```
