### PR TITLE
fix(worker): fix PVC RBAC resource

### DIFF
--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -22,7 +22,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "secrets", "persistentVolumeClaims"]
+  resources: ["pods", "secrets", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
Annoying RBAC quirk; the PVC resource is `persistentvolumeclaims`, not `persistentVolumeClaims`.

This PR fixes worker PVC creation on Kubernetes v1.7.x and v1.8.x:

Kubernetes 1.7.x:

```
$ brig run -f brigade.js deis/empty-testbed
Started brigade-worker-01bzggaa605r80cdvg6gym49mf-master
yarn run v1.3.2
$ node prestart.js
prestart: src/brigade.js written
$ node --no-deprecation ./dist/src/index.js
Creating PVC named brigade-worker-01bzggaa605r80cdvg6gym49mf-master
FATAL: [object Object] (rejection)
error handler is cleaning up
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Kubernetes 1.8.x:
```
$ brig run -f brigade.js deis/empty-testbed
Started brigade-worker-01bzgenb74g976gj1c7zbj4cep-master
yarn run v1.3.2
$ node prestart.js
prestart: src/brigade.js written
$ node --no-deprecation ./dist/src/index.js
Creating PVC named brigade-worker-01bzgenb74g976gj1c7zbj4cep-master
FATAL: persistentvolumeclaims is forbidden: User "system:serviceaccount:default:brigade-worker" cannot create persistentvolumeclaims in the namespace "default" (rejection)
error handler is cleaning up
error Command failed with exit code 1.
```
