### PR TITLE
feat(worker): allow disabling privileged mode at project level

### DIFF
--- a/brigade-worker/src/events.ts
+++ b/brigade-worker/src/events.ts
@@ -156,6 +156,11 @@ export class Project {
      */
     secrets: {[key:string]: string};
 
+    /**
+     * allowPrivilegedJobs enables privileged mode.
+     */
+    allowPrivilegedJobs: boolean;
+
     /*
      * allowHostMounts enables whether or not builds can mount in host volumes.
      */

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -270,7 +270,8 @@ export class JobRunner implements jobs.JobRunner {
       this.secret.data["main.sh"] = b64enc(newCmd)
     }
 
-    if (job.privileged) {
+    // If the job askes for privileged mode and the project allows this, enable it.
+    if (job.privileged && project.allowPrivilegedJobs) {
       for (let i = 0; i < this.runner.spec.containers.length; i++) {
         this.runner.spec.containers[i].securityContext.privileged = true
       }
@@ -603,6 +604,7 @@ export function secretToProject(ns: string, secret: kubernetes.V1Secret): Projec
       cloneURL: null,
     },
     secrets: {},
+    allowPrivilegedJobs: true,
     allowHostMounts: false
   }
   if (secret.data.vcsSidecar) {
@@ -613,6 +615,9 @@ export function secretToProject(ns: string, secret: kubernetes.V1Secret): Projec
   }
   if (secret.data.secrets) {
     p.secrets = JSON.parse(b64dec(secret.data.secrets))
+  }
+  if (secret.data.allowPrivilegedJobs) {
+    p.allowPrivilegedJobs = (b64dec(secret.data.allowPrivilegedJobs) == 'true')
   }
   if (secret.data.allowHostMounts) {
     p.allowHostMounts = (b64dec(secret.data.allowHostMounts) == 'true')

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -265,6 +265,18 @@ describe("k8s", function() {
           }
         })
       })
+      context("when the project has privileged mode disabled", function(){
+        beforeEach(function() {
+          p.allowPrivilegedJobs = false
+        })
+        it("does not allow privileged jobs", function(){
+          j.privileged = true
+          let jr = new k8s.JobRunner(j, e, p)
+          for (let c of jr.runner.spec.containers) {
+            assert.notExists(c.securityContext.privileged)
+          }
+        })
+      })
       context("when image pull secrets are supplied", function() {
         it("sets imagePullSecrets", function() {
           j.imagePullSecrets = ["one", "two"]

--- a/brigade-worker/test/mock.ts
+++ b/brigade-worker/test/mock.ts
@@ -17,7 +17,9 @@ export function mockProject(): Project {
     kubernetes: {
       namespace: "default",
       vcsSidecar: "deis/git-sidecar:latest"
-    }
+    },
+    allowPrivilegedJobs: true,
+    allowHostMounts: false,
   } as Project
 }
 

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -27,6 +27,7 @@ data:
   {{ if .Values.sshKey }}
   sshKey: {{.Values.sshKey | replace "\n" "$" | b64enc }}
   {{- end }}
+  allowPrivilegedJobs: {{ default "true" .Values.allowPrivilegedJobs | b64enc }}
   {{ if .Values.allowHostMounts -}}
   allowHostMounts: {{b64enc .Values.allowHostMounts }}
   {{ else }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -55,6 +55,12 @@ secrets: {}
 # OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
 # vcsSidecar: "deis/git-sidecar:latest"
 
+
+# Allow Jobs to run in privileged mode. This will allow features like
+# Docker-in-Docker. This must be set to true before turning allowHostMounts
+# on.
+allowPrivilegedJobs: "true"
+
 # OPTIONAL: Use this to allow host mounted docker sockets in your jobs.
 # This is a big security risk if your project is public-facing; enable at your own risk.
 # allowHostMounts: "true"


### PR DESCRIPTION
This makes it possible to disable the ability of a job to enter
privileged mode. A project can now disable the feature for all jobs.