### PR TITLE
feat(worker): add the ability to configure the image pull policy of a job

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -139,6 +139,8 @@ export abstract class Job {
   public env: {[key: string]:string}
   /** image is the container image to be run*/
   public image: string = brigadeImage
+  /** imageForcePull defines the container image pull policy: Always if true or IfNotPresent if false */
+  public imageForcePull: boolean = false
   /**
    * imagePullSecrets names secrets that contain the credentials for pulling this
    * image or the sidecar image.
@@ -191,9 +193,10 @@ export abstract class Job {
    * image is the container image to use
    * tasks is a list of commands to run.
    */
-  constructor(name: string, image?: string, tasks?: string[]) {
+  constructor(name: string, image?: string, tasks?: string[], imageForcePull?: boolean) {
     this.name = name
     this.image = image
+    this.imageForcePull = imageForcePull
     this.tasks = tasks || []
     this.env = {}
     this.cache = new JobCache()

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -125,7 +125,7 @@ export class JobRunner implements jobs.JobRunner {
     let runnerName = this.name
 
     this.secret = newSecret(secName)
-    this.runner = newRunnerPod(runnerName, job.image)
+    this.runner = newRunnerPod(runnerName, job.image, job.imageForcePull)
 
     // Experimenting with setting a deadline field after which something
     // can clean up existing builds.
@@ -507,7 +507,7 @@ function sidecarSpec(e: BrigadeEvent, local: string, image: string, project: Pro
   return spec
 }
 
-function newRunnerPod(podname: string, brigadeImage: string): kubernetes.V1Pod {
+function newRunnerPod(podname: string, brigadeImage: string, imageForcePull: boolean): kubernetes.V1Pod {
   let pod = new kubernetes.V1Pod()
   pod.metadata = new kubernetes.V1ObjectMeta()
   pod.metadata.name = podname
@@ -520,7 +520,7 @@ function newRunnerPod(podname: string, brigadeImage: string): kubernetes.V1Pod {
   c1.name = "brigaderun"
   c1.image = brigadeImage
   c1.command = ["/bin/sh", "/hook/main.sh"]
-  c1.imagePullPolicy = "IfNotPresent"
+  c1.imagePullPolicy = imageForcePull ? "Always" : "IfNotPresent"
   c1.securityContext = new kubernetes.V1SecurityContext()
 
   pod.spec = new kubernetes.V1PodSpec()

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -37,6 +37,12 @@ describe("job", function() {
           assert.equal(j.image, "alpine:3.4")
         })
       })
+      context("when imageForcePull is supplied", function() {
+        it("sets imageForcePull property", function() {
+          j = new mock.MockJob("myName", "alpine:3.4", [], true)
+          assert.isTrue(j.imageForcePull)
+        })
+      })
       context("when tasks are supplied", function() {
         it("sets task list", function() {
           j = new mock.MockJob("my", "img", ["a", "b", "c"])


### PR DESCRIPTION
When we use a container image with the `latest` tag for a job and when we run this one, then we should be able to force a pull.