### PR TITLE
Limit the clone depth at 50 to speed up builds

### DIFF
--- a/git-sidecar/rootfs/clone.sh
+++ b/git-sidecar/rootfs/clone.sh
@@ -6,7 +6,7 @@ set -x
 : "${VCS_REPO:?}"
 : "${VCS_REVISION:?}"
 
-git clone "${VCS_REPO}" "${VCS_LOCAL_PATH}"
+git clone --depth=50 "${VCS_REPO}" "${VCS_LOCAL_PATH}"
 cd "${VCS_LOCAL_PATH}"
 
 git fetch origin "${VCS_REVISION}"


### PR DESCRIPTION
It prevents downloading the full repository's history. This trick speeds up builds when repos are old and big.
Travis uses the same strategy.