### PR TITLE
fix(git-sidecar): add openssh back in

### DIFF
--- a/git-sidecar/Dockerfile
+++ b/git-sidecar/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:edge
 RUN apk update && apk add --no-cache \
     ca-certificates \
     git \
+    openssh-client \
     && update-ca-certificates
 
 COPY rootfs /


### PR DESCRIPTION
When we switched from debian:jessie-slim to alpine:3.6, openssh was no
longer included by default. That broke git SSH support.

Closes #175