### PR TITLE
fix(charts): add roles to services, deployments, pods

### DIFF
--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -8,12 +8,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    role: api
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: {{ template "brigade.fullname" . }}-api
+        role: api
     spec:
       serviceAccountName: {{ template "brigade.api.fullname" . }}
       containers:

--- a/charts/brigade/templates/api-service.yaml
+++ b/charts/brigade/templates/api-service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "brigade.api.fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    role: api
 spec:
   type: {{ .Values.api.service.type }}
   ports:

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -8,12 +8,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    role: controller
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: {{ $fullname }}
+        role: controller
     spec:
       serviceAccountName: {{ $fullname }}
       containers:

--- a/charts/brigade/templates/gateway-cr-service.yaml
+++ b/charts/brigade/templates/gateway-cr-service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ template "brigade.cr.fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    role: gateway
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/brigade/templates/gateway-service.yaml
+++ b/charts/brigade/templates/gateway-service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "brigade.gw.fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    role: gateway
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This adds the role label to several chart members, and cleans up some of
the other labels.

Closes #167