### PR TITLE
docs(brig): Mention where the brigade source needs to be cloned

### DIFF
--- a/brig/README.md
+++ b/brig/README.md
@@ -47,7 +47,7 @@ The output of the master process is written to STDOUT.
 ## Building Brig
 
 To build Brig, clone the [Brigade repository](https://github.com/Azure/brigade)
-and then run `make bootstrap brig`.
+to `$GOPATH/src/github.com/Azure/brigade` and then run `make bootstrap brig`.
 
 ## How Brig Works
 


### PR DESCRIPTION
In order to successfully build `brig`, you need to clone the brigade source
into your `$GOPATH`.  Mention this in the docs to avoid confusion for folks
that are less familiar with the idiosyncrasies of building go packages.