### PR TITLE
feat(vacuum): add brigade-vacuum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ brigade-api/rootfs/brigade-api
 brigade-controller/rootfs/brigade-controller
 brigade-gateway/rootfs/brigade-gateway
 brigade-cr-gateway/rootfs/brigade-cr-gateway
+brigade-vacuum/rootfs/brigade-vacuum
 brigade-worker/dist
 brigade-worker/doc/
 bin/

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ DOCKER_REGISTRY    ?= deis
 DOCKER_BUILD_FLAGS :=
 LDFLAGS            :=
 
-BINS        = brigade-api brigade-controller brigade-gateway brig brigade-cr-gateway
-IMAGES      = brigade-api brigade-controller brigade-gateway brigade-worker git-sidecar brigade-cr-gateway
-DOCKER_BINS = brigade-api brigade-controller brigade-gateway brigade-cr-gateway
+BINS        = brigade-api brigade-controller brigade-gateway brig brigade-cr-gateway brigade-vacuum
+IMAGES      = brigade-api brigade-controller brigade-gateway brigade-worker git-sidecar brigade-cr-gateway brigade-vacuum
+DOCKER_BINS = brigade-api brigade-controller brigade-gateway brigade-cr-gateway brigade-vacuum
 
 GIT_TAG   = $(shell git describe --tags --always 2>/dev/null)
 VERSION   ?= ${GIT_TAG}

--- a/brigade-vacuum/Dockerfile
+++ b/brigade-vacuum/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.7
+COPY rootfs/brigade-vacuum /usr/bin/brigade-vacuum
+CMD /usr/bin/brigade-vacuum

--- a/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
@@ -1,0 +1,139 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+
+	"github.com/Azure/brigade/brigade-vacuum/cmd/brigade-vacuum/vacuum"
+	"github.com/Azure/brigade/pkg/storage/kube"
+)
+
+const (
+	envKubeConfig = "KUBECONFIG"
+	envMaxBuilds  = "VACUUM_MAX_BUILDS"
+	envAge        = "VACUUM_AGE"
+	envNamespace  = "BRIGADE_NAMESPACE"
+)
+
+const mainUsage = `Clean up old Brigade builds
+
+brigade-vacuum deletes old data left by builds. It is configurable so that
+administrators can determine how often they want to flush data from the system.
+
+There are two ways to identify which records should be removed:
+
+- age: Any records older than the given age will be vacuumed up.
+- max-builds: An absolute limit on the number of builds retained.
+
+The two can be combined. Setting a zero-value for either one will remove the limit.
+
+AGE VALUES
+==========
+
+The '--age' parameter can take a valid string duration with any of these suffixes:
+
+- h: hour
+- m: minute
+- s: second
+- ns, us, and ms: nano-, µ-, and milli-seconds.
+
+Note that unless the vacuum is run with high frequency, smaller values are not
+particularly useful.
+`
+
+var (
+	globalKubeConfig = ""
+	globalNamespace  = ""
+	globalAge        = ""
+	globalVerbose    = false
+	globalMaxBuilds  = -1
+)
+
+func init() {
+	f := Root.PersistentFlags()
+	f.StringVarP(&globalNamespace, "namespace", "n", "", "The Kubernetes namespace for Brigade")
+	f.StringVarP(&globalAge, "age", "a", "", "Age as a fuzzy date ('48h' for hours, '20m' for minutes, '2000s' for seconds)")
+	f.IntVarP(&globalMaxBuilds, "max-builds", "m", 0, "Maxinum number of builds to keep")
+	f.BoolVarP(&globalVerbose, "verbose", "v", false, "Turn on verbose output")
+	f.StringVar(&globalKubeConfig, "kubeconfig", "", "The path to a KUBECONFIG file, overrides $KUBECONFIG.")
+}
+
+var Root = &cobra.Command{
+	Use:   "brigade-vacuum",
+	Short: "Clean up old Brigade builds",
+	Long:  mainUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		a := getAge()
+		mb := maxBuilds()
+		if a == "" && mb == 0 {
+			return errors.New("one of --age or --max-builds must be greater than zero")
+		}
+		var age = time.Time{}
+		if a != "" {
+			dur, err := time.ParseDuration(a)
+			if err != nil {
+				return err
+			}
+			age = time.Now().Add(-dur)
+		}
+		c, err := kube.GetClient("", kubeConfigPath())
+		if err != nil {
+			return err
+		}
+		if globalVerbose {
+			fmt.Fprintf(os.Stderr, "Max Age: %s\nMax Builds: %d\n", age, globalMaxBuilds)
+		}
+		count, err := vacuum.New(age, mb, c, ns()).Run()
+		fmt.Fprintf(os.Stdout, "Deleted %d\n", count)
+		return err
+	},
+}
+
+func kubeConfigPath() string {
+	if globalKubeConfig != "" {
+		return globalKubeConfig
+	}
+	if v, ok := os.LookupEnv(envKubeConfig); ok {
+		return v
+	}
+	return os.ExpandEnv("$HOME/.kube/config")
+}
+
+func ns() string {
+	if globalNamespace != "" {
+		return globalNamespace
+	}
+	if v, ok := os.LookupEnv(envNamespace); ok {
+		return v
+	}
+	return v1.NamespaceDefault
+}
+
+func maxBuilds() int {
+	if globalMaxBuilds > -1 {
+		return globalMaxBuilds
+	}
+	v, ok := os.LookupEnv(envMaxBuilds)
+	if !ok {
+		return 0
+	}
+	m, err := strconv.Atoi(v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Ignoring non-int value %q", v)
+		return 0
+	}
+	return m
+}
+
+func getAge() string {
+	if globalAge != "" {
+		return globalAge
+	}
+	return os.Getenv(envAge)
+}

--- a/brigade-vacuum/cmd/brigade-vacuum/main.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/brigade/brigade-vacuum/cmd/brigade-vacuum/commands"
+)
+
+func main() {
+	if err := commands.Root.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
@@ -1,0 +1,143 @@
+package vacuum
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	buildFilter = "component = build, heritage = brigade"
+	jobFilter   = "component in (build, job), heritage = brigade, build = %s"
+)
+
+type Vacuum struct {
+	age       time.Time
+	max       int
+	namespace string
+	client    kubernetes.Interface
+}
+
+func New(age time.Time, max int, client kubernetes.Interface, ns string) *Vacuum {
+	return &Vacuum{
+		age:       age,
+		max:       max,
+		client:    client,
+		namespace: ns,
+	}
+}
+
+func (v *Vacuum) Run() (int, error) {
+	opts := metav1.ListOptions{
+		LabelSelector: buildFilter,
+	}
+
+	deleted := 0
+
+	if !v.age.IsZero() {
+		log.Printf("Pruning records older than %s", v.age)
+		secrets, err := v.client.CoreV1().Secrets(v.namespace).List(opts)
+		if err != nil {
+			return 0, err
+		}
+		for _, s := range secrets.Items {
+			ts := s.ObjectMeta.CreationTimestamp.Time
+			bid, ok := s.ObjectMeta.Labels["build"]
+			if !ok {
+				log.Printf("Build %q has no build ID. Skipping.\n", s.Name)
+				continue
+			}
+			if v.age.After(ts) {
+				if err := v.deleteBuild(bid); err != nil {
+					log.Printf("Failed to delete build %s: %s (age)\n", bid, err)
+					continue
+				}
+				deleted++
+			}
+		}
+	}
+
+	// If no max, return now.
+	if v.max == 0 {
+		return deleted, nil
+	}
+
+	// We need to re-load the secrets list and see if we are still over the max.
+	secrets, err := v.client.CoreV1().Secrets(v.namespace).List(opts)
+	if err != nil {
+		return deleted, err
+	}
+	l := len(secrets.Items)
+	if l > v.max {
+		sort.Sort(ByCreation(secrets.Items))
+		for i := v.max; i < l; i++ {
+			// Delete secret and builds
+			s := secrets.Items[i]
+			bid, ok := s.ObjectMeta.Labels["build"]
+			if !ok {
+				log.Printf("Build %q has no build ID. Skipping.\n", s.Name)
+				continue
+			}
+			if err := v.deleteBuild(bid); err != nil {
+				log.Printf("Failed to delete build %s: %s (max)\n", bid, err)
+				continue
+			}
+			deleted++
+		}
+	}
+
+	return deleted, nil
+}
+
+func (v *Vacuum) deleteBuild(bid string) error {
+	opts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf(jobFilter, bid),
+	}
+	delOpts := metav1.NewDeleteOptions(0)
+	secrets, err := v.client.CoreV1().Secrets(v.namespace).List(opts)
+	if err != nil {
+		return err
+	}
+	for _, s := range secrets.Items {
+		log.Printf("Deleting secret %q", s.Name)
+		if err := v.client.CoreV1().Secrets(v.namespace).Delete(s.Name, delOpts); err != nil {
+			log.Printf("failed to delete job secret %s (continuing): %s", s.Name, err)
+		}
+	}
+
+	pods, err := v.client.CoreV1().Pods(v.namespace).List(opts)
+	if err != nil {
+		return err
+	}
+	for _, p := range pods.Items {
+		log.Printf("Deleting pod %q", p.Name)
+		if err := v.client.CoreV1().Pods(v.namespace).Delete(p.Name, delOpts); err != nil {
+			log.Printf("failed to delete job pod %s (continuing): %s", p.Name, err)
+		}
+	}
+
+	// As a safety condition, we might also consider deleting PVCs.
+	return nil
+}
+
+// ByCreation sorts secrets by their creation timestamp.
+type ByCreation []v1.Secret
+
+func (b ByCreation) Len() int {
+	return len(b)
+}
+
+func (b ByCreation) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b ByCreation) Less(i, j int) bool {
+	jj := b[j].ObjectMeta.CreationTimestamp.Time
+	ii := b[i].ObjectMeta.CreationTimestamp.Time
+	return ii.After(jj)
+}

--- a/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum_test.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum_test.go
@@ -1,0 +1,199 @@
+package vacuum
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRun_Age(t *testing.T) {
+	client := setupFakeClient()
+
+	secrets, err := client.CoreV1().Secrets(v1.NamespaceDefault).List(meta.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secrets.Items) != 3 {
+		t.Fatalf("expected 3 secrets, got %d", len(secrets.Items))
+	}
+	pods, err := client.CoreV1().Pods(v1.NamespaceDefault).List(meta.ListOptions{})
+	if err != nil {
+		t.Fatal("no pods returned")
+	}
+	if len(pods.Items) != 3 {
+		t.Fatalf("expected 3 pods, got %d", len(pods.Items))
+	}
+
+	num, err := New(time.Now(), 0, client, v1.NamespaceDefault).Run()
+	if err != nil {
+		t.Errorf("I blame fakeclient: %s", err)
+	}
+
+	// We expect one build (two pods, two secrets) to be deleted.
+	if num != 1 {
+		t.Errorf("expected 1 deletion, got %d", num)
+	}
+
+	secrets, _ = client.CoreV1().Secrets(v1.NamespaceDefault).List(meta.ListOptions{})
+	if len(secrets.Items) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(secrets.Items))
+	}
+	pods, _ = client.CoreV1().Pods(v1.NamespaceDefault).List(meta.ListOptions{})
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected 1 pods, got %d", len(pods.Items))
+	}
+}
+
+func TestRun_Max(t *testing.T) {
+	client := setupFakeClient()
+	num, err := New(time.Time{}, 1, client, v1.NamespaceDefault).Run()
+	if err != nil {
+		t.Errorf("error running: %s", err)
+	}
+
+	// We expect one build (two pods, two secrets) to be deleted.
+	if num != 1 {
+		t.Errorf("expected 1 deletion, got %d", num)
+	}
+
+	secrets, _ := client.CoreV1().Secrets(v1.NamespaceDefault).List(meta.ListOptions{})
+	if len(secrets.Items) != 1 {
+		t.Errorf("expected 1 secret, got %d", len(secrets.Items))
+	}
+	pods, _ := client.CoreV1().Pods(v1.NamespaceDefault).List(meta.ListOptions{})
+	if len(pods.Items) != 1 {
+		t.Errorf("expected 1 pods, got %d", len(pods.Items))
+	}
+
+	// It should be the case that the newest pod is the one left. However,
+	// the fake client goes by insertion order.
+	if pods.Items[0].Name != "jim" {
+		t.Errorf("expected jim to be the last pod, got %q", pods.Items[0].Name)
+	}
+	if secrets.Items[0].Name != "scrooge" {
+		t.Errorf("expected scrooge to be the last secret, got %q", secrets.Items[0].Name)
+	}
+}
+
+// setupFakeClient creates a fake Kubernetes client with some "old" data.
+func setupFakeClient() kubernetes.Interface {
+	client := fake.NewSimpleClientset()
+
+	ts := time.Now().AddDate(0, -1, 0)
+	started := meta.NewTime(ts)
+
+	buildSecret := v1.Secret{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "queequeg",
+			Namespace: v1.NamespaceDefault,
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "build",
+				"project":   "moby-dick",
+				"build":     "123456",
+			},
+			CreationTimestamp: started,
+		},
+	}
+
+	jobSecret := v1.Secret{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "tashtego",
+			Namespace: v1.NamespaceDefault,
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "job",
+				"project":   "moby-dick",
+				"build":     "123456",
+			},
+			CreationTimestamp: started,
+		},
+	}
+	unrelatedSecret := v1.Secret{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "scrooge",
+			Namespace: v1.NamespaceDefault,
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "build",
+				"project":   "christmas-carol",
+				"build":     "723457",
+			},
+			CreationTimestamp: meta.NewTime(time.Now().AddDate(1, 0, 0)),
+		},
+	}
+
+	cs := client.CoreV1().Secrets(v1.NamespaceDefault)
+	cs.Create(&buildSecret)
+	cs.Create(&jobSecret)
+	cs.Create(&unrelatedSecret)
+
+	buildPod := v1.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "queequeg",
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "build",
+				"project":   "moby-dick",
+				"build":     "123456",
+			},
+			CreationTimestamp: started,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "foo",
+				},
+			},
+		},
+	}
+	jobPod := v1.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "tashtego",
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "job",
+				"project":   "moby-dick",
+				"build":     "123456",
+			},
+			CreationTimestamp: started,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "foo",
+				},
+			},
+		},
+	}
+	unrelatedPod := v1.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name: "jim",
+			Labels: map[string]string{
+				"heritage":  "brigade",
+				"component": "job",
+				"project":   "hart-of-darkness",
+				"build":     "923456",
+			},
+			CreationTimestamp: started,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "foo",
+				},
+			},
+		},
+	}
+
+	cb := client.CoreV1().Pods(v1.NamespaceDefault)
+	cb.Create(&buildPod)
+	cb.Create(&jobPod)
+	cb.Create(&unrelatedPod)
+
+	return client
+}

--- a/charts/brigade/templates/vacuum-cronjob.yaml
+++ b/charts/brigade/templates/vacuum-cronjob.yaml
@@ -1,0 +1,31 @@
+{{ if .Values.vacuum.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "brigade.fullname" . }}-vacuum
+  labels:
+    app: {{ template "brigade.fullname" . }}-vacuum
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    role: vacuum
+spec:
+  schedule: "{{ default "@hourly" .Values.vacuum.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .Chart.Name }}-vacuum
+            image: "{{ .Values.vacuum.registry }}/{{ .Values.vacuum.name }}:{{ default .Chart.AppVersion .Values.vacuum.tag }}"
+            env:
+            - name: VACUUM_AGE
+              value: {{ default "" .Values.vacuum.age | quote }}
+            - name: VACUUM_MAX_BUILDS
+              value: {{ default "0" .Values.vacuum.maxBuilds | quote }}
+            - name: BRIGADE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          restartPolicy: OnFailure
+{{ end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -96,6 +96,35 @@ cr:
     externalPort: 80
     internalPort: 8000
 
+# The vacuum periodically cleans up old builds.
+# Brigade does not delete builds on completion. Instead, it leaves builds around
+# for a period of time, providing you with an opportunity to inspect builds for
+# data.
+# The vacuum will sweep the system at intervals and clear out old builds.
+#
+# To globally turn of the vacuum, set enabled=false
+vacuum:
+  enabled: true
+  # Set a schedule for how frequently this check is run.
+  # Note that a run of the vacuum typically takes at least a minute. Finer-level
+  # granularity than that may result in multiple vacuums running at once.
+  # Format follows accepted Cron formats: https://en.wikipedia.org/wiki/Cron
+  schedule: "@hourly"
+  registry: "deis"
+  name: "brigade-vacuum"
+  # tag: latest
+  # Age tells the vacuum how old a thing may be before it is considered ready to
+  # be vacuumed. The format is an integer followed by the suffix h (hours), m (minutes)
+  # or s (seconds).
+  # The default is 30 days (720 hours)
+  age: "720h"
+  # maxBuilds tells the vacuum what the absolute maximum number of builds may be stored
+  # at a time. Where possible, we recommend using age rather than builds.
+  # 0 means no limit is imposed.
+  #
+  # If both age and maxBuilds are provided, age is applied first, then maxBuilds.
+  maxBuilds: 0
+
 # The service is for the Brigade gateway. If you do not want to have Brigade
 # listening for incomming GitHub requests, disable this.
 service:


### PR DESCRIPTION
This cleans old builds.

A new CronJob is added that runs the brigade-vacuum every hour. By default, the vacuum cleans up any builds older than 30 days. It removes all of the pods and secrets associated with expired builds.