### PR TITLE
Correct ports and path for CR documentation

### DIFF
--- a/docs/topics/dockerhub.md
+++ b/docs/topics/dockerhub.md
@@ -48,14 +48,14 @@ The repository _must_ support web hooks.
 The URL pattern for calling a webhook is this:
 
 ```
-http://<YOUR GATEWAY>:7744/events/dockerhub/<YOUR  PROJECT NAME>/<COMMIT>
+http://<YOUR GATEWAY>:8000/events/webhook/<YOUR PROJECT NAME>/<COMMIT>
 ```
 
 For example, to connect to the project `technosophos/example-hook` and use the head
 commit, we would use:
 
 ```
-http://technosophos.brigade.sh:7744/events/dockerhub/technosophos/example-hook/master
+http://technosophos.brigade.sh:8000/events/webhook/technosophos/example-hook/master
 ```
 
 For DockerHub, this URL is added in the `webhooks` tab of the Docker repository for


### PR DESCRIPTION
I think this inconsistency comes from the breakout of the cr-gateway with the latest release.

I saw that the brigade-cr gateway wasn't listening on 7744, and it also didn't use the `dockerhub` event, rather the actual string `webhook`:

https://github.com/Azure/brigade/blob/7b2f3836620ac13862e5cee4793a86cfac6b8a2e/brigade-cr-gateway/cmd/brigade-cr-gateway/server.go#L55