### PR TITLE
fix(git-sidecar): don't shallow clone repository

### DIFF
--- a/git-sidecar/rootfs/clone.sh
+++ b/git-sidecar/rootfs/clone.sh
@@ -6,7 +6,7 @@ set -x
 : "${VCS_REPO:?}"
 : "${VCS_REVISION:?}"
 
-git clone --depth=50 "${VCS_REPO}" "${VCS_LOCAL_PATH}"
+git clone "${VCS_REPO}" "${VCS_LOCAL_PATH}"
 cd "${VCS_LOCAL_PATH}"
 
 git fetch origin "${VCS_REVISION}"


### PR DESCRIPTION
See issue #228 .

Doing a shallow clone either requires us to know if the `VCS_REVISION` parameter is a branch or named tag. If it is a branch or named tag, the script should include the `--single-branch=VCS_REVISION` along with the depth parameter. If it's a commit hash, I'm pretty sure you have to do an entire clone to support commit hashes that are not at the tip of a given branch.