### PR TITLE
Allow API and gateway to respect port values

### DIFF
--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -76,7 +76,7 @@ func defaultAPIPort() string {
 	if port, ok := os.LookupEnv("BRIGADE_API_PORT"); ok {
 		return port
 	}
-	return "7744"
+	return "7745"
 }
 
 func cors(c *gin.Context) {

--- a/brigade-gateway/cmd/brigade-gateway/server.go
+++ b/brigade-gateway/cmd/brigade-gateway/server.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	gin "gopkg.in/gin-gonic/gin.v1"
 	"k8s.io/api/core/v1"
 
 	"github.com/Azure/brigade/pkg/storage/kube"
@@ -18,6 +19,7 @@ var (
 	kubeconfig              string
 	master                  string
 	namespace               string
+	gatewayPort             string
 	buildForkedPullRequests bool
 )
 
@@ -25,6 +27,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&master, "master", "", "master url")
 	flag.StringVar(&namespace, "namespace", defaultNamespace(), "kubernetes namespace")
+	flag.StringVar(&gatewayPort, "gateway-port", defaultGatewayPort(), "TCP port to use for brigade-gateway")
 	flag.BoolVar(&buildForkedPullRequests, "build-forked-pull-requests", defaultBuildForkedPRs(), "build forked pull requests")
 }
 
@@ -49,7 +52,8 @@ func main() {
 
 	router.GET("/healthz", healthz)
 
-	router.Run(":7744")
+	formattedGatewayPort := fmt.Sprintf(":%v", gatewayPort)
+	router.Run(formattedGatewayPort)
 }
 
 func defaultNamespace() string {
@@ -57,6 +61,13 @@ func defaultNamespace() string {
 		return ns
 	}
 	return v1.NamespaceDefault
+}
+
+func defaultGatewayPort() string {
+	if port, ok := os.LookupEnv("BRIGADE_GATEWAY_PORT"); ok {
+		return port
+	}
+	return "7745"
 }
 
 func defaultBuildForkedPRs() bool {

--- a/brigade-gateway/cmd/brigade-gateway/server.go
+++ b/brigade-gateway/cmd/brigade-gateway/server.go
@@ -67,7 +67,7 @@ func defaultGatewayPort() string {
 	if port, ok := os.LookupEnv("BRIGADE_GATEWAY_PORT"); ok {
 		return port
 	}
-	return "7745"
+	return "7744"
 }
 
 func defaultBuildForkedPRs() bool {

--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -37,6 +37,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: BRIGADE_API_PORT
+            value: {{ default "7744" .Values.api.service.internalPort }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
 {{ end }}

--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: BRIGADE_API_PORT
-            value: {{ default "7744" .Values.api.service.internalPort }}
+            value: {{ .Values.api.service.internalPort | quote }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
 {{ end }}

--- a/charts/brigade/templates/gateway-deployment.yaml
+++ b/charts/brigade/templates/gateway-deployment.yaml
@@ -42,6 +42,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: BRIGADE_BUILD_FORKED_PULL_REQUESTS
             value: {{ default "" .Values.gw.buildForkedPullRequests }}
+          - name: BRIGADE_GATEWAY_PORT
+            value: {{ default "7745" .Values.service.internalPort }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
 {{ end }}

--- a/charts/brigade/templates/gateway-deployment.yaml
+++ b/charts/brigade/templates/gateway-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - name: BRIGADE_BUILD_FORKED_PULL_REQUESTS
             value: {{ default "" .Values.gw.buildForkedPullRequests }}
           - name: BRIGADE_GATEWAY_PORT
-            value: {{ default "7745" .Values.service.internalPort }}
+            value: {{ .Values.service.internalPort | quote }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}
 {{ end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -59,8 +59,8 @@ api:
   service:
     name: brigade-api
     type: ClusterIP
-    externalPort: 7744
-    internalPort: 7744
+    externalPort: 7745
+    internalPort: 7745
 
 # worker is the JavaScript worker. These are created on demand by the controller.
 worker:
@@ -130,8 +130,8 @@ vacuum:
 service:
   name: brigade-service
   type: LoadBalancer
-  externalPort: 7745
-  internalPort: 7745
+  externalPort: 7744
+  internalPort: 7744
 # By default, this is off. If you enable it, you might want to change the
 # service.type to ClusterIP
 ingress:

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -59,8 +59,8 @@ api:
   service:
     name: brigade-api
     type: ClusterIP
-    externalPort: 7745
-    internalPort: 7745
+    externalPort: 7744
+    internalPort: 7744
 
 # worker is the JavaScript worker. These are created on demand by the controller.
 worker:

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -130,8 +130,8 @@ vacuum:
 service:
   name: brigade-service
   type: LoadBalancer
-  externalPort: 7744
-  internalPort: 7744
+  externalPort: 7745
+  internalPort: 7745
 # By default, this is off. If you enable it, you might want to change the
 # service.type to ClusterIP
 ingress:


### PR DESCRIPTION
Discovered while fixing the default api/gateway port values in the chart that the corresponding binaries were hard-coded and thus would ignore the overrides, leaving the pods in a crash backoff loop.

```
kubectl get svc | egrep "api|gw"
NAME                         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)          AGE
brigade-server-brigade-api   ClusterIP      10.0.148.241   <none>          7744/TCP         45m
brigade-server-brigade-gw    LoadBalancer   10.0.31.107    52.161.94.103   7745:31857/TCP   45m

$ kubectl get po | egrep "api|gw"
NAME                                             READY     STATUS             RESTARTS   AGE
brigade-server-brigade-api-c758d8756-zt6pn       0/1       Running            17         44m
brigade-server-brigade-gw-757d586dbd-crtdx       0/1       CrashLoopBackOff   11         27m
```

Also put an import alias in for `gin` as VS Code didn't seem to recognize it...