### PR TITLE
fix(cr-gateway): support branch names with slashes

### DIFF
--- a/brigade-cr-gateway/cmd/brigade-cr-gateway/server_test.go
+++ b/brigade-cr-gateway/cmd/brigade-cr-gateway/server_test.go
@@ -41,14 +41,20 @@ func TestNewRouter(t *testing.T) {
 
 	// Basically, we're testing to make sure the route exists, but having it bail
 	// before it hits the GitHub API.
-	res, err = http.Post(ts.URL+"/events/webhook/deis/empty-testbed/master", "application/json", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
+	routes := []string{
+		"/events/webhook/brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac",
+		"/events/webhook/deis/empty-testbed",
+		"/events/webhook/deis/empty-testbed/master",
 	}
-	if res.StatusCode != 400 {
-		t.Fatalf("Expected bad status, got: %s", res.Status)
+	for _, r := range routes {
+		res, err = http.Post(ts.URL+r, "application/json", bytes.NewBuffer(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.StatusCode != 400 {
+			t.Fatalf("Expected bad status, got: %s", res.Status)
+		}
 	}
-
 }
 
 type mockStore struct {

--- a/docs/topics/dockerhub.md
+++ b/docs/topics/dockerhub.md
@@ -64,6 +64,26 @@ your image.
 For Azure Container Registry, this URL is added on the `webhooks` tab of your
 ACR repository's blade.
 
+### Alternative Webhook Paths
+
+In addition to the format above, you may use either of these paths as alternatives.
+These may be useful in cases where your project name or commit ID do not
+match the path-like assumptions of the above:
+
+```
+http://<YOUR GATEWAY>:8000/events/webhook/<YOUR PROJECT Name>?commit=<COMMIT>
+http://<YOUR GATEWAY>:8000/events/webhook/<YOUR PROJECT ID>?commit=<COMMIT>
+```
+
+So the following URLs are also valid:
+
+
+```
+http://technosophos.brigade.sh:8000/events/webhook/technosophos/example-hook?commit=master
+http://technosophos.brigade.sh:8000/events/webhook/brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac?commit=master
+```
+
+
 ## Configuring your `brigade.js`
 
 To answer hooks in your `brigade.sh`, you will need to do something like this:

--- a/pkg/webhook/dockerhub.go
+++ b/pkg/webhook/dockerhub.go
@@ -27,10 +27,19 @@ func NewDockerPushHook(s storage.Store) *dockerPushHook {
 
 // Handle handles a Push webhook event from DockerHub or a compatible agent.
 func (s *dockerPushHook) Handle(c *gin.Context) {
+	var pname, commit string
 	orgName := c.Param("org")
-	projName := c.Param("project")
-	commit := c.Param("commit")
-	pname := fmt.Sprintf("%s/%s", orgName, projName)
+	projName := c.Param("repo")
+	log.Println(projName)
+	if projName != "" {
+		pname = fmt.Sprintf("%s/%s", orgName, projName)
+	} else {
+		pname = orgName
+	}
+	if commit = c.Query("commit"); commit == "" {
+		commit = c.Param("commit")
+	}
+	log.Printf("Fetching commit %s for %s", commit, pname)
 
 	body, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {


### PR DESCRIPTION
This adds support for a commit=? query param. It also adds support for
specifying project by its long (hashed) name instead of org/project.

Closes #229