### PR TITLE
docs(scripting): add advanced events section

### DIFF
--- a/docs/topics/examples/brigade-18.js
+++ b/docs/topics/examples/brigade-18.js
@@ -1,0 +1,9 @@
+const {events} = require("brigadier")
+
+events.on("exec", function(e, project) {
+  events.emit("next", e, project)
+})
+
+events.on("next", () => {
+  console.log("fired 'next' event")
+})

--- a/docs/topics/examples/brigade-19.js
+++ b/docs/topics/examples/brigade-19.js
@@ -1,0 +1,16 @@
+const {events} = require("brigadier")
+
+events.on("exec", function(e, project) {
+  const e2 = {
+    type: "next",
+    provider: "exec-handler",
+    buildID: e.buildID,
+    workerID: e.workerID,
+    cause: {event: e}
+  }
+  events.fire(e2, project)
+})
+
+events.on("next", (e) => {
+  console.log(`fired ${e.type} caused by ${e.cause.event.type}`)
+})

--- a/docs/topics/examples/brigade-20.js
+++ b/docs/topics/examples/brigade-20.js
@@ -1,0 +1,10 @@
+const {events} = require("brigadier")
+
+events.on("exec", () => {
+  console.log("first")
+})
+
+events.on("exec", () => {
+  console.log("second")
+})
+

--- a/docs/topics/examples/brigade-21.js
+++ b/docs/topics/examples/brigade-21.js
@@ -1,0 +1,14 @@
+const {events} = require("brigadier")
+
+events.on("exec", (e, project) => {
+  // This is only registered when 'exec' is called.
+  events.on("next", () => {
+    console.log("fired 'next' event")
+  })
+  events.emit("next", e, project)
+})
+
+events.on("exec2", (e, project) => {
+  events.emit("next", e, project)
+})
+


### PR DESCRIPTION
This adds a section that covers advanced event handling, like nesting
events, firing events, and declaring multiple event handlers.

It also adds information on using DinD instead of the Docker socket.