### PR TITLE
fix(chart): fix ingress name and app label.

### DIFF
--- a/charts/brigade/templates/ingress.yaml
+++ b/charts/brigade/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "brigade.fullname" . -}}
+{{- $serviceName := include "brigade.gw.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "brigade.fullname" . }}
+  name: {{ $serviceName }}
   labels:
-    app: {{ .Release.Name }}
+    app: {{ template "brigade.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
The ingress name was incorrect, as was the app label. Brought these back
into line with the Brigade GW.