### PR TITLE
fix(controller): Label worker pods with os=linux label.

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -112,6 +112,12 @@ func TestController(t *testing.T) {
 	if ic.VolumeMounts[0].Name != sidecarVolumeName {
 		t.Errorf("expected sidecar volume %q, got %q", sidecarVolumeName, ic.VolumeMounts[0].Name)
 	}
+
+	if os, ok := pod.Spec.NodeSelector["beta.kubernetes.io/os"]; !ok {
+		t.Error("No OS node selector found")
+	} else if os != "linux" {
+		t.Errorf("Unexpected node selector: %s", os)
+	}
 }
 
 func TestController_WithScript(t *testing.T) {

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -73,6 +73,9 @@ func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
 
 	podSpec := v1.PodSpec{
 		ServiceAccountName: serviceAccount,
+		NodeSelector: map[string]string{
+			"beta.kubernetes.io/os": "linux",
+		},
 		Containers: []v1.Container{{
 			Name:            "brigade-runner",
 			Image:           c.WorkerImage,


### PR DESCRIPTION
On mixed clusters, this will make sure that worker nodes are only
deployed to Linux nodes in the cluster.

Closes #253