### PR TITLE
feat(worker): allow overriding of the job's service account.

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -163,6 +163,17 @@ export abstract class Job {
    */
   public privileged: boolean = false;
 
+  /** The account identity to be used when running this job.
+   * This is an optional way to override the build-wide service account. If it is
+   * not specified, the main worker service account will be used.
+   *
+   * Different Brigade worker implementations may choose to honor or ignore this
+   * for security or configurability reasons.
+   *
+   * See https://github.com/Azure/brigade/issues/251
+   */
+  public serviceAccount: string;
+
   /**
    * host expresses expectations about the host the job will run on.
    */

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -74,6 +74,13 @@ describe("job", function() {
           assert.deepEqual(j.tasks, ["a", "b", "c"])
         })
       })
+      context("when serviceAccount is supplied", function() {
+        it("sets serviceAccount property", function() {
+          j = new mock.MockJob("myName", "alpine:3.4", [], true)
+          j.serviceAccount = "svcAccount"
+          assert.equal(j.serviceAccount, "svcAccount")
+        })
+      })
     })
     describe("#podName", function() {
       beforeEach(function(){

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -117,6 +117,21 @@ describe("k8s", function() {
           assert.equal(jr.secret.metadata.labels.commit, "master")
         })
       })
+      context("when service account is specified", function() {
+        beforeEach(function() {
+          j.serviceAccount = "svcAccount"
+        })
+        it("sets a service account name for the pod", function() {
+          let jr= new k8s.JobRunner(j, e, p)
+          assert.equal(jr.runner.spec.serviceAccountName, "svcAccount")
+        })
+      })
+      context("when no service account is specified", function() {
+        it("sets a service account name to 'brigade-worker'", function() {
+          let jr= new k8s.JobRunner(j, e, p)
+          assert.equal(jr.runner.spec.serviceAccountName, "brigade-worker")
+        })
+      })
       context("when no tasks are supplied", function() {
         beforeEach(function() {
           j.tasks = []

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -184,6 +184,7 @@ Properties of `Job`
 - `cache: JobCache`: Preferences for the job's cache
 - `storage: JobStorage`: Preferences for the way this job attaches to the build storage
 - `docker: JobDockerMount`: Preferences for mounting a Docker socket
+- `serviceAccount: string`: The name of the service account to use (if you need to override the default).
 
 #### The `job.podName()` method
 


### PR DESCRIPTION
This allows you to set a `job.serviceAccount` that Kubernetes will use
to run the job.

Closes #251