### PR TITLE
Add pods/log resource to api role

### DIFF
--- a/charts/brigade/templates/api-role.yaml
+++ b/charts/brigade/templates/api-role.yaml
@@ -22,7 +22,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "secrets"]
+  resources: ["pods", "secrets", "pods/log"]
   verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
In order to be able to retrieve logs througth API its needed access to `pods/logs` resource