### PR TITLE
fix(chart): the pod/log permission is needed on the worker's role

### DIFF
--- a/brigade-worker/src/brigadier.ts
+++ b/brigade-worker/src/brigadier.ts
@@ -54,6 +54,7 @@ export class Job extends jobImpl.Job {
     this._podName = jr.name;
     return jr.run().catch(err => {
       // Wrap the message to give clear context.
+      console.error(err)
       let msg = `job ${this.name}(${jr.name}): ${err}`;
       return Promise.reject(new Error(msg));
     });

--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -22,7 +22,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "secrets", "persistentvolumeclaims"]
+  resources: ["pods", "secrets", "persistentvolumeclaims", "pods/log"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
pods/log permission is needed to allow the worker to clean up jobs. It
was missing in the 0.8.0 and earlier charts, and the result is a very
unhelpful error message.

Closes #186
Closes #247