### PR TITLE
WIP feat(tests): add brigade target to run functional test in cluster

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -69,3 +69,38 @@ events.on("image_push", (e, p) => {
     console.log(m)
   }
 })
+
+events.on("functional_test", (e, p) => {
+  var gopath = "/go"
+
+  // To set GOPATH correctly, we have to override the default
+  // path that Brigade sets.
+  var localPath = gopath + "/src/github.com/" + p.repo.name;
+
+
+  // Create a new job to run Go tests
+  var goBuild = new Job("brigade-test", "golang:1.9");
+
+  const j = new Job("functional-test", "golang:1.9")
+  j.env = {
+    GOPATH: "/src"
+  }
+
+  // Set a few environment variables.
+  j.env = {
+      "DEST_PATH": localPath,
+      "GOPATH": gopath
+  };
+
+  // Run Go unit tests
+  j.tasks = [
+    "go get github.com/golang/dep/cmd/dep",
+    "mkdir -p " + localPath,
+    "mv /src/* " + localPath,
+    "cd " + localPath,
+    "dep ensure",
+	  "go run ./tests/cmd/generate.go " + e.commit,
+    "go test --tags integration ./tests"
+  ]
+  j.run()
+})

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -11,6 +11,12 @@ import (
 )
 
 func TestFunctional(t *testing.T) {
+
+	host := os.Getenv("BRIGADE_BRIGADE_GITHUB_GW_SERVICE_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+
 	githubPushFile, err := os.Open("testdata/test-repo-generated.json")
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +29,7 @@ func TestFunctional(t *testing.T) {
 	requests := []*http.Request{
 		{
 			Method: "POST",
-			URL:    &url.URL{Scheme: "http", Host: "localhost:7744", Path: "/events/github"},
+			URL:    &url.URL{Scheme: "http", Host: host + ":7744", Path: "/events/github"},
 			Body:   githubPushFile,
 			Header: http.Header{
 				"X-Github-Event":  []string{"push"},


### PR DESCRIPTION
This adds an event to brigade.js that lets us run the functional tests
inside of a cluster.