### PR TITLE
feat(*): use typed secrets for projects, builds, and jobs

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/informer.go
+++ b/brigade-controller/cmd/brigade-controller/controller/informer.go
@@ -4,40 +4,21 @@ import (
 	"log"
 
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 )
 
 func (c *Controller) createIndexerInformer() {
-	labelSelector := labels.Set{
-		"heritage":  "brigade",
-		"component": "build",
-	}
+	selector := fields.OneTermEqualSelector("type", "brigade.sh/build")
+	watcher := cache.NewListWatchFromClient(c.clientset.CoreV1().RESTClient(), "secrets", c.Namespace, selector)
 
-	c.indexer, c.informer = cache.NewIndexerInformer(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.LabelSelector = labelSelector.String()
-				return c.clientset.CoreV1().Secrets(c.Namespace).List(options)
-			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.LabelSelector = labelSelector.String()
-				return c.clientset.CoreV1().Secrets(c.Namespace).Watch(options)
-			},
+	c.indexer, c.informer = cache.NewIndexerInformer(watcher, &v1.Secret{}, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if key, err := cache.MetaNamespaceKeyFunc(obj); err == nil {
+				log.Println("Adding to workqueue: ", key)
+				c.queue.Add(key)
+			}
 		},
-		&v1.Secret{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				if key, err := cache.MetaNamespaceKeyFunc(obj); err == nil {
-					log.Println("Adding to workqueue: ", key)
-					c.queue.Add(key)
-				}
-			},
-		},
-		cache.Indexers{},
-	)
+	}, cache.Indexers{})
+
 }

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -597,6 +597,7 @@ function newRunnerPod(
 
 function newSecret(name: string): kubernetes.V1Secret {
   let s = new kubernetes.V1Secret();
+  s.type = "brigade.sh/job"
   s.metadata = new kubernetes.V1ObjectMeta();
   s.metadata.name = name;
   s.metadata.labels = {

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -10,7 +10,7 @@ metadata:
     component: project
   annotations:
     projectName: {{ .Values.project | quote }}
-type: Opaque
+type: "brigade.sh/project"
 data:
   repository: {{ .Values.repository | b64enc }}
   sharedSecret: {{ .Values.sharedSecret | b64enc }}

--- a/docs/topics/examples/simple-event/cron/cron-event.sh
+++ b/docs/topics/examples/simple-event/cron/cron-event.sh
@@ -32,7 +32,7 @@ metadata:
     build: ${uuid}
     commit: ${commit}
     component: build
-type: Opaque
+type: "brigade.sh/build"
 data:
   commit: $(echo -n "${commit}" | base64 -w 0)
   event_provider: $(echo -n "${event_provider}" | base64 -w 0)

--- a/docs/topics/examples/simple-event/simple-event.sh
+++ b/docs/topics/examples/simple-event/simple-event.sh
@@ -52,7 +52,7 @@ while : ; do
       build: ${uuid}
       commit: ${commit}
       component: build
-  type: Opaque
+  type: "brigade.sh/build"
   data:
     commit: $(echo -n "${commit}" | base64 $b64flags)
     event_provider: $(echo -n "${event_provider}" | base64 $b64flags)

--- a/docs/topics/gateways.md
+++ b/docs/topics/gateways.md
@@ -85,7 +85,7 @@ metadata:
     component: build
 
     # Any other labels you add will be ignored by Brigade.
-type: Opaque
+type: brigade.sh/build
 data:
   # IMPORTANT: We show these fields as clear text, but they MUST be base-64
   # encoded.
@@ -183,7 +183,7 @@ while : ; do
       build: ${uuid}
       commit: ${commit}
       component: build
-  type: Opaque
+  type: "brigade.sh/build"
   data:
     commit: $(echo -n "${commit}" | base64)
     event_provider: $(echo -n "${event_provider}" | base64)
@@ -247,7 +247,7 @@ metadata:
     build: ${uuid}
     commit: ${commit}
     component: build
-type: Opaque
+type: "brigade.sh/build"
 data:
   commit: $(echo -n "${commit}" | base64 -w 0)
   event_provider: $(echo -n "${event_provider}" | base64 -w 0)

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Azure/brigade/pkg/brigade"
 )
 
+const secretTypeBuild = "brigade.sh/build"
+
 // GetBuild returns the build.
 func (s *store) GetBuild(id string) (*brigade.Build, error) {
 	build := &brigade.Build{ID: id}
@@ -57,6 +59,7 @@ func (s *store) CreateBuild(build *brigade.Build) error {
 				"project":   build.ProjectID,
 			},
 		},
+		Type: secretTypeBuild,
 		Data: map[string][]byte{
 			"script":  build.Script,
 			"payload": build.Payload,

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -12,6 +12,7 @@ func TestConfigureProject(t *testing.T) {
 		ObjectMeta: meta.ObjectMeta{
 			Name: "brigadeTest",
 		},
+		Type: secretTypeBuild,
 		Data: map[string][]byte{
 			"repository":   []byte("myrepo"),
 			"sharedSecret": []byte("mysecret"),

--- a/scripts/functional-test-secret.sh
+++ b/scripts/functional-test-secret.sh
@@ -37,7 +37,7 @@ metadata:
     commit: ${commit}
     jobname: ${name}
     component: build
-type: Opaque
+type: "brigade.sh/build"
 data:
   commit: $(echo -n "${commit}" | base64)
   event_provider: $(echo -n "${event_provider}" | base64)


### PR DESCRIPTION
Assign a type to kubernetes secrets storing configuration for projects,
builds, and jobs.

This will simplify queries and provide distinction for debugging.

```
$ kubectl get secrets
NAME                                                             TYPE                                  DATA      AGE
brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac   brigade.sh/project                    8         1h
brigade-brigade-api-token-t4vw8                                  kubernetes.io/service-account-token   3         1h
brigade-brigade-cr-gw-token-m8sss                                kubernetes.io/service-account-token   3         1h
brigade-brigade-ctrl-token-2z5zz                                 kubernetes.io/service-account-token   3         1h
brigade-brigade-github-gw-token-kxg77                            kubernetes.io/service-account-token   3         1h
brigade-f1ccf2ad3495a1c68b82c78789061036240a9eb5ea2f0b0c4c20f9   brigade.sh/project                    6         1h
brigade-worker-01c5qe5qf8ypdbmz7zh5q3qrxk-589e1502               brigade.sh/build                      7         28m
brigade-worker-token-656m2                                       kubernetes.io/service-account-token   3         1h
default-token-tbczv                                              kubernetes.io/service-account-token   3         2d
node-runner-1517983823420-589e1502                               brigade.sh/job                        3         18m
slack-notify-1517983827460-589e1502                              brigade.sh/job                        6         18m
```