### PR TITLE
fix(chart): turn vcsSidecar on by  default

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -136,11 +136,12 @@ func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
 		Spec: podSpec,
 	}
 
-	// Skip adding the sidecar pod if it's not necessary.
+	// Skip adding the sidecar pod if the script is provided already.
 	if s, ok := secret.Data["script"]; ok && len(s) > 0 {
 		return pod, nil
 	}
 
+	// Skip adding the sidecar pod if no sidecar pod image is supplied.
 	if image, ok := project.Data[vcsSidecarKey]; ok && len(image) > 0 {
 		pod.Spec.InitContainers = []v1.Container{{
 			Name:            "vcs-sidecar",

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -56,8 +56,12 @@ secrets:
 # you know what you are doing.
 # namespace: "default"
 
-# OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
-# vcsSidecar: "deis/git-sidecar:latest"
+# RECOMMENDED: vcsSidecar is the image that fetches a repo from a VCS
+# The default sidecar uses Git to fetch a copy of the project. Commenting this
+# out will prevent the worker from using a sidecar. This may improve performance
+# very slightly, but will break some gateways or cause the default script to
+# be used.
+vcsSidecar: "deis/git-sidecar:latest"
 
 # OPTIONAL: buildStorageSize is the size of the shared storage space used by the jobs
 # buildStorageSize: "50Mi"


### PR DESCRIPTION
This enables the vcsSidecar param by default in values.yaml. This will
cause the worker to use the vcsSidecar as an init container. Omiting it
prevents the worker from declaring a sidecar pod, which means passing
the brigade.js file is incumbent upon the gateways.

Closes #305