### PR TITLE
fix(github): support using GitHub Enterprise

### DIFF
--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -27,6 +27,9 @@ sharedSecret: "IBrakeForSeaBeasts"
 # This is REQUIRED for the GitHub gateway, but optional otherwise.
 github:
 #   token: "github oauth token"
+#   ENTERPRISE: For enterprise GitHub customers, set both of these as well.
+#   baseURL: "https://internal.github.url/foo"
+#   uploadURL: "https://internal.github.url/foo"
 
 # OPTIONAL: Use this for private repositories
 # This is the PRIVATE key that Brigade will use to clone a private repo.

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -66,6 +66,13 @@ func shortSHA(input string) string {
 type Github struct {
 	// Token is used for oauth2 for client interactions.
 	Token string `json:"-"`
+	// BaseURL is used to construct an Enterprise GitHub client.
+	// If not supplied, the assumption is that we are connecting to
+	// github.com.
+	BaseURL string `json:"baseURL"`
+	// UploadURL is the upload URL to be used for GitHub enterprise.
+	// Typically, it is the same as the BaseURL.
+	UploadURL string `json:"uploadURL"`
 }
 
 // Repo describes a Git repository.

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -53,6 +53,8 @@ func NewProjectFromSecret(secret *v1.Secret, namespace string) (*brigade.Project
 	proj.Name = secret.Annotations["projectName"]
 	proj.SharedSecret = def(secret.Data["sharedSecret"], "")
 	proj.Github.Token = string(secret.Data["github.token"])
+	proj.Github.BaseURL = string(secret.Data["github.baseURL"])
+	proj.Github.UploadURL = string(secret.Data["github.uploadURL"])
 
 	proj.Kubernetes.Namespace = def(secret.Data["namespace"], namespace)
 	proj.Kubernetes.VCSSidecar = def(secret.Data["vcsSidecar"], "")

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -18,6 +18,8 @@ func TestConfigureProject(t *testing.T) {
 			"defaultScript":     []byte(`console.log("hello default script")`),
 			"sharedSecret":      []byte("mysecret"),
 			"github.token":      []byte("like a fish needs a bicycle"),
+			"github.baseURL":    []byte("https://example.com/base"),
+			"github.uploadURL":  []byte("https://example.com/upload"),
 			"sshKey":            []byte("hello$world"),
 			"namespace":         []byte("zooropa"),
 			"secrets":           []byte(`{"bar":"baz","foo":"bar"}`),
@@ -51,6 +53,12 @@ func TestConfigureProject(t *testing.T) {
 	}
 	if proj.Github.Token != "like a fish needs a bicycle" {
 		t.Error("Fish cannot find its bicycle")
+	}
+	if proj.Github.BaseURL != "https://example.com/base" {
+		t.Errorf("Unexpected base URL: %s", proj.Github.BaseURL)
+	}
+	if proj.Github.UploadURL != "https://example.com/upload" {
+		t.Errorf("Unexpected upload URL: %s", proj.Github.UploadURL)
 	}
 	if proj.Repo.SSHKey != "hello\nworld" {
 		t.Errorf("Unexpected SSHKey: %q", proj.Repo.SSHKey)

--- a/pkg/webhook/client_test.go
+++ b/pkg/webhook/client_test.go
@@ -1,0 +1,27 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/Azure/brigade/pkg/brigade"
+)
+
+func TestGHClient(t *testing.T) {
+	gh := brigade.Github{
+		Token:     "totallyFake",
+		BaseURL:   "http://example.com/base/",
+		UploadURL: "http://example.com/upload/",
+	}
+
+	c, err := ghClient(gh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.BaseURL.String() != gh.BaseURL {
+		t.Errorf("Expected %q, got %q", c.BaseURL.String(), gh.BaseURL)
+	}
+	if c.UploadURL.String() != gh.UploadURL {
+		t.Errorf("Expected %q, got %q", c.UploadURL.String(), gh.UploadURL)
+	}
+}


### PR DESCRIPTION
This adds support for specifying the API endpoint URL for GitHub
Enterprise. If none is set, it defaults to regular GitHub API.

Closes #241