### PR TITLE
fix(chart): make worker service account configurable

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller.go
@@ -15,9 +15,10 @@ import (
 
 // Config is config for setting Controller
 type Config struct {
-	Namespace        string
-	WorkerImage      string
-	WorkerPullPolicy string
+	Namespace            string
+	WorkerImage          string
+	WorkerPullPolicy     string
+	WorkerServiceAccount string
 }
 
 // Controller listens for new brigade builds and starts the worker pods.

--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -22,10 +22,12 @@ func TestController(t *testing.T) {
 		t.Log("creating pod")
 		return false, nil, nil
 	})
+	svcAccountName := "my-service-account"
 	config := &Config{
-		Namespace:        v1.NamespaceDefault,
-		WorkerImage:      "deis/brigade-worker:latest",
-		WorkerPullPolicy: string(v1.PullIfNotPresent),
+		Namespace:            v1.NamespaceDefault,
+		WorkerImage:          "deis/brigade-worker:latest",
+		WorkerPullPolicy:     string(v1.PullIfNotPresent),
+		WorkerServiceAccount: svcAccountName,
 	}
 	controller := NewController(client, config)
 
@@ -78,6 +80,10 @@ func TestController(t *testing.T) {
 
 	if !labels.Equals(pod.GetLabels(), secret.GetLabels()) {
 		t.Error("Pod.Lables do not match")
+	}
+
+	if pod.Spec.ServiceAccountName != svcAccountName {
+		t.Errorf("expected service account %s, got %s", svcAccountName, pod.Spec.ServiceAccountName)
 	}
 
 	if pod.Spec.Volumes[0].Name != volumeName {
@@ -203,7 +209,6 @@ func TestController_WithScript(t *testing.T) {
 	if pod.Spec.Volumes[0].Name != volumeName {
 		t.Error("Spec.Volumes are not correct")
 	}
-
 	c := pod.Spec.Containers[0]
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -64,11 +64,10 @@ const (
 	sidecarVolumePath        = "/vcs"
 	vcsSidecarKey            = "vcsSidecar"
 	workerCommandKey         = "workerCommand"
-  workerImageRegistryKey   = "worker.registry"
+	workerImageRegistryKey   = "worker.registry"
 	workerImageNameKey       = "worker.name"
 	workerImageTagKey        = "worker.tag"
 	workerImagePullPolicyKey = "worker.pullPolicy"
-	serviceAccount    = "brigade-worker"
 )
 
 func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
@@ -85,7 +84,7 @@ func (c *Controller) newWorkerPod(secret, project *v1.Secret) (v1.Pod, error) {
 	image, pullPolicy := c.workerImageConfig(project)
 
 	podSpec := v1.PodSpec{
-		ServiceAccountName: serviceAccount,
+		ServiceAccountName: c.Config.WorkerServiceAccount,
 		NodeSelector: map[string]string{
 			"beta.kubernetes.io/os": "linux",
 		},

--- a/brigade-controller/cmd/brigade-controller/main.go
+++ b/brigade-controller/cmd/brigade-controller/main.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const defaultWorkerServiceAccountName = "brigade-worker"
+
 func init() {
 	log.SetFlags(log.Lshortfile)
 }
@@ -28,6 +30,7 @@ func main() {
 	flag.StringVar(&ctrConfig.Namespace, "namespace", defaultNamespace(), "kubernetes namespace")
 	flag.StringVar(&ctrConfig.WorkerImage, "worker-image", defaultWorkerImage(), "kubernetes worker image")
 	flag.StringVar(&ctrConfig.WorkerPullPolicy, "worker-pull-policy", defaultWorkerPullPolicy(), "kubernetes worker image pull policy")
+	flag.StringVar(&ctrConfig.WorkerServiceAccount, "worker-service-account", defaultWorkerServiceAccount(), "kubernetes worker service account name")
 	flag.Parse()
 
 	// creates the connection
@@ -66,6 +69,13 @@ func defaultWorkerPullPolicy() string {
 		return pp
 	}
 	return string(v1.PullIfNotPresent)
+}
+
+func defaultWorkerServiceAccount() string {
+	if pp, ok := os.LookupEnv("BRIGADE_WORKER_SERVICE_ACCOUNT"); ok {
+		return pp
+	}
+	return defaultWorkerServiceAccountName
 }
 
 func defaultNamespace() string {

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -33,5 +33,7 @@ spec:
             value: "{{ .Values.worker.registry }}/{{ .Values.worker.name }}:{{ default .Chart.AppVersion .Values.worker.tag }}"
           - name: BRIGADE_WORKER_PULL_POLICY
             value: {{ default "IfNotPresent" .Values.worker.pullPolicy }}
+          - name: BRIGADE_WORKER_SERVICE_ACCOUNT
+            value: {{ default "brigade-worker" .Values.worker.serviceAccount }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}

--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -1,9 +1,10 @@
 {{ $fname := include "brigade.worker.fullname" . }}
+{{ $serviceAccount := default "brigade-worker" .Values.worker.serviceAccount }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: brigade-worker
+  name: {{ $serviceAccount }}
   labels:
     app: {{ template "brigade.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -36,7 +37,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: brigade-worker
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -75,6 +75,7 @@ api:
 worker:
   registry: deis
   name: brigade-worker
+  serviceAccount: brigade-worker
   #tag:
   #pullPolicy: IfNotPresent
 

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -15,7 +15,7 @@ func TestConfigureProject(t *testing.T) {
 		Type: secretTypeBuild,
 		Data: map[string][]byte{
 			"repository":        []byte("myrepo"),
-			"defaultScript": []byte(`console.log("hello default script")`),
+			"defaultScript":     []byte(`console.log("hello default script")`),
 			"sharedSecret":      []byte("mysecret"),
 			"github.token":      []byte("like a fish needs a bicycle"),
 			"sshKey":            []byte("hello$world"),


### PR DESCRIPTION
This makes it possible to configure the service account used by the
worker. The main change is to the controller, which now accepts a worker
service account.

Closes #157