### PR TITLE
charts/brigade: add job limits for vacuum

### DIFF
--- a/charts/brigade/templates/vacuum-cronjob.yaml
+++ b/charts/brigade/templates/vacuum-cronjob.yaml
@@ -11,6 +11,8 @@ metadata:
     role: vacuum
 spec:
   schedule: "{{ default "@hourly" .Values.vacuum.schedule }}"
+  successfulJobsHistoryLimit: {{ default 10 .Values.vacuum.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 10 .Values.vacuum.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
- adds successfulJobsHistoryLimit to the template
- adds failedJobsHistoryLimit to the template