### PR TITLE
Add brig proxy command to start tunnels to api and kashti

### DIFF
--- a/brig/cmd/brig/commands/proxy.go
+++ b/brig/cmd/brig/commands/proxy.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/brigade/pkg/portforwarder"
+	"github.com/Azure/brigade/pkg/storage/kube"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	proxyUsage = `Creates a tunnel to the Kashti component.`
+	apiPort    = 7745
+	remotePort = 80
+)
+
+var port int
+
+func init() {
+	Root.AddCommand(proxy)
+
+	flags := proxy.PersistentFlags()
+	flags.IntVar(&port, "port", 8081, "local port for the Kashti dashboard")
+}
+
+var proxy = &cobra.Command{
+	Use:   "proxy",
+	Short: "proxy",
+	Long:  proxyUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return startProxy(port)
+	},
+}
+
+func startProxy(kashtiPort int) error {
+
+	configLocation := kubeConfigPath()
+	config, err := clientcmd.BuildConfigFromFlags("", configLocation)
+	if err != nil {
+		return err
+	}
+
+	c, err := kube.GetClient("", configLocation)
+	if err != nil {
+		return err
+	}
+
+	apiSelector := labels.Set{"role": "api"}.AsSelector()
+	_, err = portforwarder.New(c, config, "default", apiSelector, apiPort, apiPort)
+	if err != nil {
+		return fmt.Errorf("cannot start port forward for brigade api: %v", err)
+	}
+
+	kashtiSelector := labels.Set{"app": "kashti"}.AsSelector()
+	_, err = portforwarder.New(c, config, "default", kashtiSelector, remotePort, port)
+	if err != nil {
+		return fmt.Errorf("cannot start port forward for kashti: %v", err)
+	}
+
+	stop := make(chan os.Signal, 2)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-stop
+		os.Exit(0)
+	}()
+
+	for {
+		fmt.Printf("connect to kashti on localhost:%d...\n", port)
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/brig/cmd/brig/commands/proxy.go
+++ b/brig/cmd/brig/commands/proxy.go
@@ -15,18 +15,23 @@ import (
 )
 
 const (
-	proxyUsage = `Creates a tunnel to the Kashti component.`
-	apiPort    = 7745
-	remotePort = 80
+	proxyUsage    = `Creates a tunnel to the Kashti component.`
+	remoteAPIPort = 7745
+	remotePort    = 80
 )
 
-var port int
+var (
+	port    int
+	apiPort int
+)
 
 func init() {
 	Root.AddCommand(proxy)
 
 	flags := proxy.PersistentFlags()
 	flags.IntVar(&port, "port", 8081, "local port for the Kashti dashboard")
+	flags.IntVar(&apiPort, "api-port", 7745, "local port for the Brigade API server")
+
 }
 
 var proxy = &cobra.Command{
@@ -52,7 +57,7 @@ func startProxy(kashtiPort int) error {
 	}
 
 	apiSelector := labels.Set{"role": "api"}.AsSelector()
-	_, err = portforwarder.New(c, config, "default", apiSelector, apiPort, apiPort)
+	_, err = portforwarder.New(c, config, "default", apiSelector, remoteAPIPort, apiPort)
 	if err != nil {
 		return fmt.Errorf("cannot start port forward for brigade api: %v", err)
 	}
@@ -71,7 +76,7 @@ func startProxy(kashtiPort int) error {
 	}()
 
 	for {
-		fmt.Printf("connect to kashti on localhost:%d...\n", port)
+		fmt.Printf("connect to kashti on http://localhost:%d\n", port)
 		time.Sleep(10 * time.Second)
 	}
 }

--- a/pkg/portforwarder/portforwarder.go
+++ b/pkg/portforwarder/portforwarder.go
@@ -1,0 +1,156 @@
+// Initial license from Helm
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforwarder
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+//New returns a tunnel to the server pod.
+func New(clientset *kubernetes.Clientset, config *rest.Config, namespace string, selector labels.Selector, remotePort, localPort int) (*Tunnel, error) {
+	pod, err := getPod(clientset, namespace, selector)
+	if err != nil {
+		return nil, err
+	}
+
+	t := NewTunnel(clientset.CoreV1().RESTClient(), config, namespace, pod.ObjectMeta.GetName(), remotePort)
+	return t, t.ForwardPort(localPort)
+}
+
+// Tunnel describes a ssh-like tunnel to a kubernetes pod
+type Tunnel struct {
+	Local     int
+	Remote    int
+	Namespace string
+	PodName   string
+	Out       io.Writer
+	stopChan  chan struct{}
+	readyChan chan struct{}
+	config    *rest.Config
+	client    rest.Interface
+}
+
+// NewTunnel creates a new tunnel
+func NewTunnel(client rest.Interface, config *rest.Config, namespace, podName string, remote int) *Tunnel {
+	return &Tunnel{
+		config:    config,
+		client:    client,
+		Namespace: namespace,
+		PodName:   podName,
+		Remote:    remote,
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		Out:       ioutil.Discard,
+	}
+}
+
+// Close disconnects a tunnel connection
+func (t *Tunnel) Close() {
+	close(t.stopChan)
+	close(t.readyChan)
+}
+
+// ForwardPort opens a tunnel to a kubernetes pod
+func (t *Tunnel) ForwardPort(localPort int) error {
+	// Build a url to the portforward endpoint
+	// example: http://localhost:8080/api/v1/namespaces/helm/pods/tiller-deploy-9itlq/portforward
+	u := t.client.Post().
+		Resource("pods").
+		Namespace(t.Namespace).
+		Name(t.PodName).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(t.config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", u)
+
+	local, err := getAvailablePort(localPort)
+	if err != nil {
+		return fmt.Errorf("could not find an available port: %s", err)
+	}
+	t.Local = local
+
+	ports := []string{fmt.Sprintf("%d:%d", t.Local, t.Remote)}
+
+	pf, err := portforward.New(dialer, ports, t.stopChan, t.readyChan, t.Out, t.Out)
+	if err != nil {
+		return err
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- pf.ForwardPorts()
+	}()
+
+	select {
+	case err = <-errChan:
+		return fmt.Errorf("forwarding ports: %v", err)
+	case <-pf.Ready:
+		return nil
+	}
+}
+
+func getAvailablePort(localPort int) (int, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", localPort))
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	_, p, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, err
+	}
+	return port, err
+}
+
+func getPod(clientset *kubernetes.Clientset, namespace string, selector labels.Selector) (*v1.Pod, error) {
+	options := metav1.ListOptions{LabelSelector: selector.String()}
+	pods, err := clientset.CoreV1().Pods(namespace).List(options)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) < 1 {
+		return nil, fmt.Errorf("could not find server")
+	}
+	for _, p := range pods.Items {
+		if p.Status.Phase == v1.PodRunning {
+			return &p, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find a ready server pod")
+}


### PR DESCRIPTION
WIP implementation of `brig proxy` that currently starts tunnels to the API and Kashti.

This way, you don't have to expose the dashboard publicly, and connecting is done through a single command.