### PR TITLE
Create the worker options on base64

### DIFF
--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -44,7 +44,7 @@ data:
   allowHostMounts: {{ b64enc "false" }}
   {{- end }}
   {{ range $k, $v := .Values.worker -}}
-  worker.{{ $k }}: {{ $v | quote }}
+  worker.{{ $k }}: {{ b64enc $v }}
   {{ end -}}
   {{if .Values.workerCommand -}}
   workerCommand: {{.Values.workerCommand | b64enc }}


### PR DESCRIPTION
This fixes the issue https://github.com/Azure/brigade/issues/345

The values on a secret have to be base64 encoded.