### PR TITLE
fix(worker) use sshKey for private repo, not brigadeSSHKey.

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -567,7 +567,7 @@ function sidecarSpec(
       name: "BRIGADE_REPO_KEY",
       valueFrom: {
         secretKeyRef: {
-          key: "brigadeSSHKey",
+          key: "sshKey",
           name: project.id
         }
       }


### PR DESCRIPTION
fix(worker) use sshKey for private repo. There is no brigadeSSHKey in the Secret data.