### PR TITLE
fix(chart): BREAKING set vcsSidecar tag to version

### DIFF
--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -19,7 +19,10 @@ data:
   {{ if .Values.defaultScript }}
   defaultScript: {{.Values.defaultScript | b64enc }}
   {{- end }}
-  {{ if .Values.vcsSidecar }}
+  {{ if eq "NONE" .Values.vcsSidecar -}}
+  {{- else if empty .Values.vcsSidecar -}}
+  vcsSidecar: {{ printf "deis/git-sidecar:%s" .Chart.Version | b64enc }}
+  {{- else }}
   vcsSidecar: {{ .Values.vcsSidecar | b64enc }}
   {{- end }}
   {{ if .Values.buildStorageSize }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -68,9 +68,13 @@ secrets:
 # you know what you are doing.
 # namespace: "default"
 
-# RECOMMENDED: vcsSidecar is the image that fetches a repo from a VCS
-# The default sidecar uses Git to fetch a copy of the project. Commenting this
-# out will prevent the worker from using a sidecar. This may improve performance
+# OPTIONAL: vcsSidecar is the image that fetches a repo from a VCS
+# The default sidecar uses Git to fetch a copy of the project.
+#
+# If this is not supplied, `deis/git-sidecar:VERSION` will be used, where VERSION
+# is the version of this chart.
+#
+# If this is set to NONE, no sidecar is used.  This may improve performance
 # very slightly, but will break some gateways or cause the default script to
 # be used.
 vcsSidecar: "deis/git-sidecar:latest"


### PR DESCRIPTION
Previously, this always used `:latest` for the vcs sidecar tag. Now it
uses .Chart.Version. In order to not use any vcsSidecar, you now have
to set the version to NONE, which is breaking, but probably an unused
feature anyway.