### PR TITLE
Create worker with sa env

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -93,8 +93,8 @@ func TestController(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 13 {
-		t.Errorf("expected 13 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 14 {
+		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -114,8 +114,8 @@ func TestController(t *testing.T) {
 		t.Fatalf("Expected 1 init container, got %d", l)
 	}
 	ic := pod.Spec.InitContainers[0]
-	if envlen := len(ic.Env); envlen != 13 {
-		t.Errorf("expected 13 env vars, got %d", envlen)
+	if envlen := len(ic.Env); envlen != 14 {
+		t.Errorf("expected 14 env vars, got %d", envlen)
 	}
 
 	if ic.Image != sidecarImage {
@@ -210,8 +210,8 @@ func TestController_WithScript(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 13 {
-		t.Errorf("expected 13 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 14 {
+		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -284,8 +284,8 @@ func TestController_NoSidecar(t *testing.T) {
 	}
 
 	c := pod.Spec.Containers[0]
-	if envlen := len(c.Env); envlen != 13 {
-		t.Errorf("expected 13 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 14 {
+		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -513,8 +513,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 			if c.Name != "brigade-runner" {
 				t.Error("Container.Name is not correct")
 			}
-			if envlen := len(c.Env); envlen != 13 {
-				t.Errorf("expected 13 items in Container.Env, got %d", envlen)
+			if envlen := len(c.Env); envlen != 14 {
+				t.Errorf("expected 14 items in Container.Env, got %d", envlen)
 			}
 			if c.Image != test.expWorkerImage {
 				t.Errorf("Container.Image is not correct, got %s; want %s", c.Image, test.expWorkerImage)
@@ -530,8 +530,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 				t.Fatalf("Expected 1 init container, got %d", l)
 			}
 			ic := pod.Spec.InitContainers[0]
-			if envlen := len(ic.Env); envlen != 13 {
-				t.Errorf("expected 13 env vars, got %d", envlen)
+			if envlen := len(ic.Env); envlen != 14 {
+				t.Errorf("expected 14 env vars, got %d", envlen)
 			}
 
 			if ic.Image != sidecarImage {

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -72,7 +72,7 @@ const (
 )
 
 func (c *Controller) newWorkerPod(build, project *v1.Secret) (v1.Pod, error) {
-	env := workerEnv(project, build)
+	env := c.workerEnv(project, build)
 
 	cmd := []string{"yarn", "-s", "start"}
 	if cmdString, ok := project.Data["workerCommand"]; ok {
@@ -191,7 +191,7 @@ func (c *Controller) workerImageConfig(project *v1.Secret) (string, string) {
 	return image, pullPolicy
 }
 
-func workerEnv(project, build *v1.Secret) []v1.EnvVar {
+func (c *Controller) workerEnv(project, build *v1.Secret) []v1.EnvVar {
 	sv := kube.SecretValues(build.Data)
 	env := []v1.EnvVar{
 		{Name: "CI", Value: "true"},
@@ -218,6 +218,7 @@ func workerEnv(project, build *v1.Secret) []v1.EnvVar {
 			Name:      "BRIGADE_REPO_AUTH_TOKEN",
 			ValueFrom: secretRef("github.token", project),
 		},
+		{Name: "BRIGADE_SERVICE_ACCOUNT", Value: c.Config.WorkerServiceAccount},
 	}
 	return env
 }

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -150,7 +150,7 @@ export class JobRunner implements jobs.JobRunner {
     this.project = project;
     this.client = defaultClient;
 
-    this.serviceAccount = process.env.BRIGADE_SERVICE_ACCOUNT || defaultServiceAccount;
+    this.serviceAccount = job.serviceAccount || process.env.BRIGADE_SERVICE_ACCOUNT || defaultServiceAccount;
 
     // $JOB-$BUILD
     this.name = `${job.name}-${this.event.buildID}`;

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -150,7 +150,7 @@ export class JobRunner implements jobs.JobRunner {
     this.project = project;
     this.client = defaultClient;
 
-    this.serviceAccount = job.serviceAccount || defaultServiceAccount;
+    this.serviceAccount = process.env.BRIGADE_SERVICE_ACCOUNT || defaultServiceAccount;
 
     // $JOB-$BUILD
     this.name = `${job.name}-${this.event.buildID}`;


### PR DESCRIPTION
This fixes the issue https://github.com/Azure/brigade/issues/355

Firstly, on the controller, when creating the worker, it adds an environmental variable called `BRIGADE_SERVICE_ACCOUNT`, so the worker knows how to launch the job pods.

Secondly, the worker reads that environmental variable when it creates the job pods. Regarding this, I don't know if it's correct or if this env should be read on `index.ts` (with the rest of the envs) and pass it somehow  to the JobRunner.