### PR TITLE
ref(worker): move env var processing to the top

### DIFF
--- a/brigade-worker/src/app.ts
+++ b/brigade-worker/src/app.ts
@@ -70,6 +70,7 @@ export class App {
     this.projectID = projectID;
     this.projectNS = projectNS;
   }
+
   /**
    * run runs a particular event for this app.
    */

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -17,6 +17,7 @@
  *   this namespace.
  * - `BRIGADE_BUILD_ID`: The ULID for the build. This is unique.
  * - `BRIGADE_BUILD_NAME`: This is actually the ID of the worker.
+ * - `BRIGADE_SERVICE_ACCOUNT`: The service account to use.
  *
  * Also, the Brigade script must be written to `brigade.js`.
  */
@@ -31,6 +32,8 @@ import * as ulid from "ulid";
 import * as events from "./events";
 import { App } from "./app";
 import { Logger, ContextLogger } from "./logger";
+
+import { options } from "./k8s";
 
 // This is a side-effect import.
 import "./brigade";
@@ -66,6 +69,10 @@ try {
   e.payload = fs.readFileSync("/etc/brigade/payload", "utf8");
 } catch (e) {
   logger.log("no payload loaded");
+}
+
+if (process.env.BRIGADE_SERVICE_ACCOUNT) {
+  options.serviceAccount = process.env.BRIGADE_SERVICE_ACCOUNT;
 }
 
 // Run the app.

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -129,6 +129,13 @@ describe("k8s", function() {
           assert.equal(jr.runner.spec.serviceAccountName, "brigade-worker");
         });
       });
+      context("when custom service account is specified", function() {
+        it("sets a service account name to 'custom-worker'", function() {
+          k8s.options.serviceAccount = "custom-worker";
+          let jr = new k8s.JobRunner(j, e, p);
+          assert.equal(jr.runner.spec.serviceAccountName, "custom-worker");
+        });
+      });
       context("when no tasks are supplied", function() {
         beforeEach(function() {
           j.tasks = [];


### PR DESCRIPTION
This is a minor refactor to move an env var reference to the top.