### PR TITLE
Make clone instructions more copy/paste-able

### DIFF
--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -28,11 +28,14 @@ This document covers development of `brigade-controller`, `brigade-server`, and
 
 Follow these steps when cloning the brigade repository to use an existing `GOPATH` for your system:
 
-- `$ export GOPATH=$(go env GOPATH) # GOPATH is set to $HOME/go by default`
-- `$ export PATH=$GOPATH/bin:$PATH # 'make bootstrap brig' will try to execute binnaries in $GOPATH/bin`
-- `$ mkdir -p $GOPATH/src/github.com/Azure `
-- `$ git clone https://github.com/Azure/brigade $GOPATH/src/github.com/Azure/brigade`
-- `$ cd $GOPATH/src/github.com/Azure/brigade`
+```bash
+export GOPATH=$(go env GOPATH) # GOPATH is set to $HOME/go by default
+export PATH=$GOPATH/bin:$PATH # 'make bootstrap brig' will try to execute binnaries in $GOPATH/bin
+mkdir -p $GOPATH/src/github.com/Azure
+git clone https://github.com/Azure/brigade $GOPATH/src/github.com/Azure/brigade
+cd $GOPATH/src/github.com/Azure/brigade
+```
+
 
 **Note**: this leaves you at the tip of **master** in the repository where active development
 is happening. You might prefer to checkout the most recent stable tag:


### PR DESCRIPTION
When I was setting this up, I had to copy/paste each line which took a bit more time. It's nice to be able to spot-check the commands and then run them all at once.