### PR TITLE
fix(brig): add verbose output for waiting

### DIFF
--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -144,6 +144,8 @@ func (a *scriptRunner) send(projectName string, data []byte) error {
 
 	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
 
+	fmt.Printf("Event created. Waiting for worker pod named %q.", podName)
+
 	if err := a.waitForWorker(b.ID); err != nil {
 		return err
 	}


### PR DESCRIPTION
One of the common Brig problems occurs when Brig creates an event, but
the controller does not start the worker. This adds a single line of
verbose output indicating (a) when Brig starts waiting for the worker,
and (b) what pod it expects to start as a worker.

Partially addresses #368