### PR TITLE
ref(worker): use client-node

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -31,7 +31,7 @@
     "typescript": "^2.4.2"
   },
   "dependencies": {
-    "@kubernetes/typescript-node": "^0.1.1",
+    "@kubernetes/client-node": "^0.1.3",
     "pretty-error": "^2.1.1",
     "ulid": "^0.2.0"
   }

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -4,7 +4,7 @@
 
 /** */
 
-import * as kubernetes from "@kubernetes/typescript-node";
+import * as kubernetes from "@kubernetes/client-node";
 import * as jobs from "./job";
 import { Logger, ContextLogger } from "./logger";
 import { BrigadeEvent, Project } from "./events";

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -6,7 +6,7 @@ import * as k8s from "../src/k8s";
 import { BrigadeEvent, Project } from "../src/events";
 import { Job, Result, brigadeCachePath, brigadeStoragePath } from "../src/job";
 
-import * as kubernetes from "@kubernetes/typescript-node";
+import * as kubernetes from "@kubernetes/client-node";
 
 describe("k8s", function() {
   describe("b64enc", () => {

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@kubernetes/typescript-node@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@kubernetes/typescript-node/-/typescript-node-0.1.1.tgz#eaec89d747d3e2f22e9d84b657fd2ed143f9179b"
+"@kubernetes/client-node@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.1.3.tgz#40b26bf6c3774cc36ac82065f1db42d9d15ca26f"
   dependencies:
     base-64 "^0.1.0"
     bluebird "^3.3.5"
+    byline "^5.0.0"
     chai "^4.1.0"
     js-yaml "^3.5.2"
     jsonpath "^0.2.11"
@@ -15,6 +16,7 @@
     request "^2.72.0"
     shelljs "^0.7.8 "
     underscore "^1.8.3"
+    websocket "^1.0.25"
 
 "@types/chai@^4.0.1":
   version "4.0.9"
@@ -190,6 +192,10 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+byline@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -306,6 +312,12 @@ dashdash@^1.12.0:
 debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -607,7 +619,7 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
@@ -821,6 +833,10 @@ mocha@^3.4.2:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+nan@^2.3.3:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nomnom@1.5.2:
   version "1.5.2"
@@ -1107,6 +1123,12 @@ type-detect@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
+typedarray-to-buffer@^3.1.2:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
@@ -1200,6 +1222,15 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+websocket@^1.0.25:
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.25.tgz#998ec790f0a3eacb8b08b50a4350026692a11958"
+  dependencies:
+    debug "^2.2.0"
+    nan "^2.3.3"
+    typedarray-to-buffer "^3.1.2"
+    yaeti "^0.0.6"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -1215,6 +1246,10 @@ wordwrap@~0.0.2:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This moves us from the typescript-node to client-node Kubernetes
packages. The package was renamed to better reflect its use for both TS
and JS.

Closes #362