### PR TITLE
Correct non-npm JS installation instructions in custom workers

### DIFF
--- a/docs/topics/workers.md
+++ b/docs/topics/workers.md
@@ -175,7 +175,7 @@ We can build this file into our Dockerfile by copying it into the image:
 FROM deis/brigade-worker:latest
 
 RUN yarn add xml-simple
-COPY mylib.js /home/dist
+COPY mylib.js /home/src/dist
 ```
 
 And now we can build the above:


### PR DESCRIPTION
It appears that the documentation for custom workers (`docs/topics/workers.md`) instructs users to `COPY` their custom files to the wrong location.  The location should be `/home/src/dist` rather than `/home/dist`.