### PR TITLE
Add 'closed' as allowed pull_request event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@
 /tests/testdata/*-generated.*
 /vendor/
 node_modules/
+
+
+# IDEs
+.vscode/
+.idea/
+
+# Developer
+pvt/

--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -7,6 +7,8 @@
 
 /** */
 
+import {V1EnvVarSource} from "@kubernetes/client-node/api";
+
 /**
  * The default shell for the job.
  */
@@ -147,7 +149,7 @@ export abstract class Job {
   /** tasks is a list of tasks run inside of the shell*/
   public tasks: string[];
   /** env is the environment variables for the job*/
-  public env: { [key: string]: string };
+  public env: { [key: string]: string | V1EnvVarSource };
   /** image is the container image to be run*/
   public image: string = brigadeImage;
   /** imageForcePull defines the container image pull policy: Always if true or IfNotPresent if false */

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -301,8 +301,30 @@ Properties:
 - `tasks`: An array of commands to run for this job
 - `shell`: The terminal emulator that job tasks will be executed under. By default,
   this is /bin/sh
-- `env`: Key/value pairs that will be injected into the environment. The key is
-  the variable name (`MY_VAR`), and the value is the string value (`foo`)
+- `env`: Key/value pairs or Kubernetes value references that will be injected into the environment. 
+  - If supplying key/value, the key is the variable name (`MY_VAR`), and the value is the string value (`foo`)
+  - If you are referencing existing Secrets or ConfigMaps in your Kubernetes cluster, the `env` object key
+    will be your secret name, and the value will be a Kubernetes reference object. `fieldRef`, `secretKeyRef`,
+    and `configMapKeyRef` are accepted. `resourceFieldRef` is technically supported but not advised, since resources
+    are not generally specified for Brigade jobs.
+  - Example: 
+    ```javascript
+    myJob.env = {
+        myOneOffSecret: "secret value",
+        myConfigReference: {
+            configMapKeyRef: {
+                name: "my-configmap",
+                key: "my-configmap-key"
+            }
+        },
+        mySecretReference: {
+            secretKeyRef: {
+                name: "my-secret",
+                key: "my-secret-key"
+            }
+        }
+    }
+    ```
 
 It is common to pass data from the `e.env` Event object into the Job object as is appropriate:
 

--- a/docs/topics/secrets.md
+++ b/docs/topics/secrets.md
@@ -103,7 +103,7 @@ to the `Job.env`?**
 Brigade is designed to use off-the-shelf Docker images. In the examples above, we used the
 `alpine:3.4` image straight from DockerHub. We wouldn't want to just automatically pass
 all of our information straight into that container. For starters, doing so might
-inadvertantly override an existing environment variable of the same name. More
+inadvertently override an existing environment variable of the same name. More
 importantly, the data might get misused or unintentionally exposed by the container.
 
 So we err on the side of safety.
@@ -114,8 +114,11 @@ We use Kubernetes Secrets for holding sensitive data. As encrypted Secrets are
 adopted into Kubernetes, we plan to support them. However, the present stable
 version of Kubernetes Secrets only Base64-encodes data.
 
-Our present recomendation is for Brigade developers to fetch the secret directly from a
+Our present recommendation is for Brigade developers to fetch the secret directly from a
 trusted key store such as Vault.
+
+Alternatively, you could use `secretKeyRef` to reference existing secrets already in your
+Kubernetes cluster.
 
 **I don't want to use Helm to manage my project/secrets. Can I do it manually?**
 

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -201,7 +201,7 @@ func (s *githubHook) isAllowedPullRequest(e *github.PullRequestEvent) bool {
 		return false
 	}
 	switch e.GetAction() {
-	case "opened", "synchronize", "reopened", "labeled", "unlabeled":
+	case "opened", "synchronize", "reopened", "labeled", "unlabeled", "closed":
 		return true
 	}
 	log.Println("unsupported pull_request action:", e.GetAction())


### PR DESCRIPTION
We're planning to use Brigade for Github automation in some ways as a replacement for Hubot.  One of the first events we plan to handle is when pull requests are closed or merged.  This PR adds `"closed"` as an allowed pull request event.

(Also updates `.gitignore`.)