### PR TITLE
feat(brig): add 'brig build logs'

### DIFF
--- a/brig/cmd/brig/commands/build_list.go
+++ b/brig/cmd/brig/commands/build_list.go
@@ -41,10 +41,14 @@ func listBuilds(out io.Writer) error {
 	}
 
 	table := uitable.New()
-	table.AddRow("ID", "TYPE", "PROVIDER", "PROJECT")
+	table.AddRow("ID", "TYPE", "PROVIDER", "PROJECT", "STATUS")
 
 	for _, b := range bs {
-		table.AddRow(b.ID, b.Type, b.Provider, b.ProjectID)
+		status := "???"
+		if b.Worker != nil {
+			status = b.Worker.Status.String()
+		}
+		table.AddRow(b.ID, b.Type, b.Provider, b.ProjectID, status)
 	}
 	fmt.Fprintln(out, table)
 	return nil

--- a/brig/cmd/brig/commands/build_logs.go
+++ b/brig/cmd/brig/commands/build_logs.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/Azure/brigade/pkg/storage"
+	"github.com/Azure/brigade/pkg/storage/kube"
+)
+
+const (
+	logHeader      = "\n==========[  %s  ]==========\n"
+	buildLogsUsage = `Show log(s) for a build
+
+Print the logs for a build, and (optionally) the jobs executed as part of the
+build.
+`
+)
+
+var (
+	logsJobs bool
+	logsLast bool
+)
+
+func init() {
+	buildLogs.Flags().BoolVarP(&logsJobs, "jobs", "j", false, "Show job logs as well as the worker log")
+	buildLogs.Flags().BoolVarP(&logsLast, "last", "l", false, "Show last build's log (ignores BUILD_ID)")
+	build.AddCommand(buildLogs)
+}
+
+var buildLogs = &cobra.Command{
+	Use:   "logs BUILD_ID",
+	Short: "show build logs",
+	Long:  buildLogsUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if logsLast {
+			return showBuildLogs(cmd.OutOrStdout(), "")
+		}
+		if len(args) == 0 {
+			return errors.New("either BUILD_ID or --last is required")
+		}
+		return showBuildLogs(cmd.OutOrStdout(), args[0])
+	},
+}
+
+func showBuildLogs(out io.Writer, buildID string) error {
+	c, err := kube.GetClient("", kubeConfigPath())
+	if err != nil {
+		return err
+	}
+
+	store := kube.New(c, globalNamespace)
+	if buildID == "" {
+		buildID, err = lastBuildID(store)
+		if err != nil {
+			return err
+		}
+	}
+
+	bs, err := store.GetBuild(buildID)
+	if err != nil {
+		return err
+	}
+
+	if bs.Worker == nil {
+		return fmt.Errorf("No logs for build %q", buildID)
+	}
+
+	workerLog, err := store.GetWorkerLog(bs.Worker)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, logHeader, bs.Worker.ID)
+	fmt.Fprint(out, workerLog)
+	if logsJobs {
+		return showJobLogs(out, bs, store)
+	}
+	return nil
+}
+
+func lastBuildID(store storage.Store) (string, error) {
+	builds, err := store.GetBuilds()
+	if err != nil {
+		return "", err
+	}
+
+	if len(builds) == 0 {
+		return "", errors.New("no builds")
+	}
+
+	return builds[len(builds)-1].ID, nil
+}
+
+func showJobLogs(out io.Writer, build *brigade.Build, store storage.Store) error {
+	// This indicates that there were no jobs because the worker never
+	// spawned.
+	if build.Worker == nil {
+		return fmt.Errorf("Build %s has no worker", build.ID)
+	}
+
+	jobs, err := store.GetBuildJobs(build)
+	if err != nil {
+		return err
+	}
+
+	for _, j := range jobs {
+		fmt.Fprintf(out, logHeader, j.ID)
+		log, err := store.GetJobLog(j)
+		if err != nil {
+			fmt.Fprintf(out, "log not found: %s", err)
+			continue
+		}
+		fmt.Fprint(out, log)
+	}
+	return nil
+}

--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -144,7 +144,7 @@ func (a *scriptRunner) send(projectName string, data []byte) error {
 
 	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
 
-	fmt.Printf("Event created. Waiting for worker pod named %q.", podName)
+	fmt.Printf("Event created. Waiting for worker pod named %q.\n", podName)
 
 	if err := a.waitForWorker(b.ID); err != nil {
 		return err

--- a/pkg/brigade/build.go
+++ b/pkg/brigade/build.go
@@ -17,7 +17,7 @@ type Build struct {
 	// Payload is the raw data as received by the webhook.
 	Payload []byte `json:"payload,omitempty"`
 	// Script is the brigadeJS to be executed.
-	Script []byte `json:"script,omityempty"`
+	Script []byte `json:"script,omitempty"`
 	// Worker is the master job that is running this build.
 	// The Worker's properties (creation time, state, exit code, and so on)
 	// reflect a "roll-up" of the job.

--- a/pkg/brigade/job.go
+++ b/pkg/brigade/job.go
@@ -7,6 +7,10 @@ import (
 // JobStatus is a label for the condition of a Job at the current time.
 type JobStatus string
 
+func (j JobStatus) String() string {
+	return string(j)
+}
+
 // These are the valid statuses of jobs.
 const (
 	// JobPending means the job has been accepted by the system, but one or more of the containers

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -14,8 +14,8 @@ func TestNewBuildFromSecret(t *testing.T) {
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"build":   "#1",
-				"project": "myproject",
+				"build":   stubBuildID,
+				"project": stubProjectID,
 			},
 		},
 		Data: map[string][]byte{
@@ -27,20 +27,169 @@ func TestNewBuildFromSecret(t *testing.T) {
 			"commit_ref":     []byte("refs/heads/master"),
 		},
 	}
-	expectedBuild := &brigade.Build{
-		ID:        "#1",
-		ProjectID: "myproject",
-		Revision: &brigade.Revision{
-			Commit: "abc123",
-			Ref:    "refs/heads/master",
-		},
-		Type:     "foo",
-		Provider: "bar",
-		Payload:  []byte("this is a payload"),
-		Script:   []byte("ohai"),
-	}
 	build := NewBuildFromSecret(secret)
-	if !reflect.DeepEqual(build, expectedBuild) {
-		t.Errorf("build differs from expected build, got '%v', expected '%v'", build, expectedBuild)
+	if !reflect.DeepEqual(build, stubBuild) {
+		t.Errorf("build differs from expected build, got '%v', expected '%v'", build, stubBuild)
+	}
+}
+
+func TestCreateBuild(t *testing.T) {
+	k, s := fakeStore()
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, _ := k.CoreV1().Secrets("default").List(metav1.ListOptions{})
+	if len(secrets.Items) != 1 {
+		t.Fatalf("Build was not stored as secret")
+	}
+}
+
+func TestGetBuild(t *testing.T) {
+	k, s := fakeStore()
+	createFakeWorker(k, stubWorkerPod)
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := s.GetBuild(stubBuild.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The one that comes back will have a worker attached, because we created
+	// one.
+	if b.Worker == nil {
+		t.Error("expected a worker")
+	}
+
+	if b.Worker.ID != stubWorkerPod.Name {
+		t.Errorf("expected worker name %s, got %s", stubWorkerPod.Name, b.Worker.ID)
+	}
+
+	if b.Worker.ProjectID != stubWorkerPod.Labels["project"] {
+		t.Errorf("expected project ID %s got %s", stubWorkerPod.Labels["project"], b.ProjectID)
+	}
+
+	if b.ProjectID != stubProjectID {
+		t.Errorf("expected build project ID %s, got %s", stubProjectID, b.ProjectID)
+	}
+}
+
+func TestGetBuilds(t *testing.T) {
+	k, s := fakeStore()
+	createFakeWorker(k, stubWorkerPod)
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately set this to an out-of-date ULID
+	secondBuildID := genID()
+	secondBuild := &brigade.Build{
+		ID:        secondBuildID,
+		ProjectID: stubProjectID,
+		Type:      "second",
+		Provider:  "mock",
+		Revision:  &brigade.Revision{Ref: "heads/refs/master"},
+	}
+	if err := s.CreateBuild(secondBuild); err != nil {
+		t.Fatal(err)
+	}
+	w2 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-id-" + secondBuildID,
+			Labels: map[string]string{
+				"build":     secondBuildID,
+				"project":   stubProjectID,
+				"component": "build",
+				"heritage":  "brigade",
+			},
+			CreationTimestamp: podStartTime,
+		},
+		Status: v1.PodStatus{
+			Phase:     v1.PodSucceeded,
+			StartTime: &podStartTime,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode:   0,
+							FinishedAt: podEndTime,
+						},
+					},
+				},
+			},
+		},
+	}
+	createFakeWorker(k, w2)
+
+	builds, err := s.GetBuilds()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(builds); l != 2 {
+		t.Fatalf("expected 2 builds, got %d", l)
+	}
+}
+
+func TestGetProjectBuilds(t *testing.T) {
+	k, s := fakeStore()
+	createFakeWorker(k, stubWorkerPod)
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deliberately set this to an out-of-date ULID
+	secondBuildID := genID()
+	secondBuild := &brigade.Build{
+		ID:        secondBuildID,
+		ProjectID: stubProjectID,
+		Type:      "second",
+		Provider:  "mock",
+		Revision:  &brigade.Revision{Ref: "heads/refs/master"},
+	}
+	if err := s.CreateBuild(secondBuild); err != nil {
+		t.Fatal(err)
+	}
+	w2 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-id-" + secondBuildID,
+			Labels: map[string]string{
+				"build":     secondBuildID,
+				"project":   stubProjectID,
+				"component": "build",
+				"heritage":  "brigade",
+			},
+			CreationTimestamp: podStartTime,
+		},
+		Status: v1.PodStatus{
+			Phase:     v1.PodSucceeded,
+			StartTime: &podStartTime,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode:   0,
+							FinishedAt: podEndTime,
+						},
+					},
+				},
+			},
+		},
+	}
+	createFakeWorker(k, w2)
+
+	proj := &brigade.Project{
+		ID: stubProjectID,
+	}
+
+	builds, err := s.GetProjectBuilds(proj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(builds); l != 2 {
+		t.Fatalf("expected 2 builds, got %d", l)
 	}
 }

--- a/pkg/storage/kube/job_test.go
+++ b/pkg/storage/kube/job_test.go
@@ -63,3 +63,39 @@ func TestNewJobFromPod(t *testing.T) {
 		t.Errorf("job differs from expected job, got '%v', expected '%v'", job, expectedJob)
 	}
 }
+
+func TestGetJob(t *testing.T) {
+	k, s := fakeStore()
+	createFakeJob(k, stubJobPod)
+
+	job, err := s.GetJob(stubJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if job.ID != stubJobID {
+		t.Errorf("Expected job ID %s, got %s", stubJobID, job.ID)
+	}
+}
+
+func TestGetBuildJob(t *testing.T) {
+	k, s := fakeStore()
+	createFakeWorker(k, stubWorkerPod)
+	createFakeJob(k, stubJobPod)
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := s.GetBuild(stubBuild.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobs, err := s.GetBuildJobs(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 1 {
+		t.Fatal("Expected one job.")
+	}
+}

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -7,6 +7,31 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestGetProjects(t *testing.T) {
+	k, s := fakeStore()
+	createFakeProject(k, stubProjectSecret)
+	projects, err := s.GetProjects()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(projects) != 1 {
+		t.Fatalf("expected one project, got %d", len(projects))
+	}
+}
+
+func TestGetProject(t *testing.T) {
+	k, s := fakeStore()
+	createFakeProject(k, stubProjectSecret)
+	proj, err := s.GetProject(stubProjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proj.ID != stubProjectID {
+		t.Error("Unexpected project ID: ", proj.ID)
+	}
+}
+
 func TestConfigureProject(t *testing.T) {
 	secret := &v1.Secret{
 		ObjectMeta: meta.ObjectMeta{

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -1,0 +1,159 @@
+package kube
+
+import (
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/Azure/brigade/pkg/storage"
+)
+
+const (
+	stubProjectID = "brigade-544b459e6ad7267e7791c4f77bfd1722a15e305a22cf9d3c60c5be"
+)
+
+var (
+	stubBuildID  = genID()
+	stubJobID    = "job-" + stubBuildID
+	now          = time.Now()
+	later        = now.Add(time.Minute)
+	podStartTime = metav1.NewTime(now)
+	podEndTime   = metav1.NewTime(later)
+)
+
+var (
+	stubWorkerPod = v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-id-" + stubBuildID,
+			Labels: map[string]string{
+				"build":     stubBuildID,
+				"project":   stubProjectID,
+				"component": "build",
+				"heritage":  "brigade",
+			},
+			CreationTimestamp: podStartTime,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "alpine:3.7",
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase:     v1.PodSucceeded,
+			StartTime: &podStartTime,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode:   0,
+							FinishedAt: podEndTime,
+						},
+					},
+				},
+			},
+		},
+	}
+	stubJobPod = v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: stubJobID,
+			Labels: map[string]string{
+				"build":     stubBuildID,
+				"project":   stubProjectID,
+				"component": "job",
+				"heritage":  "brigade",
+			},
+			CreationTimestamp: podStartTime,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Image: "alpine:3.7",
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase:     v1.PodSucceeded,
+			StartTime: &podStartTime,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode:   0,
+							FinishedAt: podEndTime,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	stubProjectSecret = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: stubProjectID,
+			Labels: map[string]string{
+				"project":   stubProjectID,
+				"component": "project",
+				"heritage":  "brigade",
+				"app":       "brigade",
+			},
+			Annotations: map[string]string{
+				"projectName": "deis/empty-testbed",
+			},
+		},
+		Type: secretTypeBuild,
+		Data: map[string][]byte{
+			"repository":        []byte("myrepo"),
+			"defaultScript":     []byte(`console.log("hello default script")`),
+			"sharedSecret":      []byte("mysecret"),
+			"github.token":      []byte("like a fish needs a bicycle"),
+			"github.baseURL":    []byte("https://example.com/base"),
+			"github.uploadURL":  []byte("https://example.com/upload"),
+			"sshKey":            []byte("hello$world"),
+			"namespace":         []byte("zooropa"),
+			"secrets":           []byte(`{"bar":"baz","foo":"bar"}`),
+			"worker.registry":   []byte("deis"),
+			"worker.name":       []byte("brigade-worker"),
+			"worker.tag":        []byte("canary"),
+			"worker.pullPolicy": []byte("Always"),
+			// Intentionally skip cloneURL, test that this is ""
+		},
+	}
+
+	// stubBuild is a build
+	stubBuild = &brigade.Build{
+		ID:        stubBuildID,
+		ProjectID: stubProjectID,
+		Revision: &brigade.Revision{
+			Commit: "abc123",
+			Ref:    "refs/heads/master",
+		},
+		Type:     "foo",
+		Provider: "bar",
+		Payload:  []byte("this is a payload"),
+		Script:   []byte("ohai"),
+	}
+)
+
+// fakeStore returns a fake Kubernetes client and a *store that wraps it.
+func fakeStore() (kubernetes.Interface, storage.Store) {
+	client := fake.NewSimpleClientset()
+	return client, New(client, "default")
+}
+
+func createFakeWorker(client kubernetes.Interface, pod v1.Pod) {
+	client.CoreV1().Pods("default").Create(&pod)
+}
+
+func createFakeJob(client kubernetes.Interface, pod v1.Pod) {
+	createFakeWorker(client, pod)
+}
+
+func createFakeProject(client kubernetes.Interface, secret *v1.Secret) {
+	client.CoreV1().Secrets("default").Create(secret)
+}

--- a/pkg/storage/kube/worker.go
+++ b/pkg/storage/kube/worker.go
@@ -17,7 +17,7 @@ import (
 // This will return an error if no worker is found for the build, which can
 // happen when a build is scheduled, but not yet started.
 func (s *store) GetWorker(buildID string) (*brigade.Worker, error) {
-	labels := labels.Set{"heritage": "brigade", "build": buildID}
+	labels := labels.Set{"heritage": "brigade", "component": "build", "build": buildID}
 	listOption := meta.ListOptions{LabelSelector: labels.AsSelector().String()}
 	pods, err := s.client.CoreV1().Pods(s.namespace).List(listOption)
 	if err != nil {

--- a/pkg/storage/kube/worker_test.go
+++ b/pkg/storage/kube/worker_test.go
@@ -57,3 +57,16 @@ func TestNewWorkerFromPod(t *testing.T) {
 		t.Errorf("worker differs from expected, got '%v', expected '%v'", worker, expect)
 	}
 }
+
+func TestGetWorker(t *testing.T) {
+	k, s := fakeStore()
+	createFakeWorker(k, stubWorkerPod)
+	worker, err := s.GetWorker(stubBuildID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if worker.ProjectID != stubProjectID {
+		t.Fatal("expected correct project ID")
+	}
+}


### PR DESCRIPTION
This gives Brig a new `build logs` subcommand for dumping logs.

Along the way, I backfilled a bunch of tests, too.