### PR TITLE
Fix: ACI connector makes it work

### DIFF
--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -50,7 +50,7 @@ const requiredEnvVar = (name: string): string => {
 
 const projectID: string = requiredEnvVar("BRIGADE_PROJECT_ID");
 const projectNamespace: string = requiredEnvVar("BRIGADE_PROJECT_NAMESPACE");
-const defaultULID = ulid();
+const defaultULID = ulid().toLocaleLowerCase();
 let e: events.BrigadeEvent = {
   buildID: process.env.BRIGADE_BUILD_ID || defaultULID,
   workerID: process.env.BRIGADE_BUILD_NAME || `unknown-${defaultULID}`,

--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -126,6 +126,16 @@ export class JobDockerMount {
 }
 
 /**
+ * Request represents request of the resources
+ */
+export class Request {
+  /** cpu requests */
+  public cpu: string;
+  /** memory requests */
+  public memory: string;
+}
+
+/**
  * Job represents a single job, which is composed of several closely related sequential tasks.
  * Jobs must have names. Every job also has an associated image, which references
  * the Docker container to be run.
@@ -173,6 +183,9 @@ export abstract class Job {
    * See https://github.com/Azure/brigade/issues/251
    */
   public serviceAccount: string;
+
+  /** Set the resource requests for the containers */
+  public requests: Request;
 
   /**
    * host expresses expectations about the host the job will run on.
@@ -226,6 +239,7 @@ export abstract class Job {
     this.storage = new JobStorage();
     this.docker = new JobDockerMount();
     this.host = new JobHost();
+    this.requests = new Request();
   }
 
   /** run executes the job and then */


### PR DESCRIPTION
Currently, ACI connector doesn't work for the Brigade. I create a pull request for fixing this.

Also, when I tried locally, I found one issue. 

```
     message: 'Secret "one-01C99SZ7D3E9B8W60EM6K731ZT" is invalid: metadata.name: Invalid value: "one-01C99SZ7D3E9B8W60EM6K731ZT": a DNS-1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')',
```
The first commit fix this issue for local execution. 

The second commit enable us to specify request cpu and memory. If we don't specify these two, ACI connector doesn't work now. 

After this change, We can write `brigade.js` like this

```
const { events, Job } = require('brigadier')

events.on("exec", (brigadeEvent, project) => {
  console.log("******** start working **********")
  var one = new Job("one")
  one.image = "alpine:3.4"
  one.tasks = ["echo hello aci"]
  one.host.os = "linux"
  one.host.name = "virtual-kubelet"
  one.requests.cpu = "1"
  one.requests.memory = "1G"
  one.run()
  console.log("******** end container **********")
})
```