### PR TITLE
fix(worker): Allow secretKeyRef and configMapKeyRef as Job env vars

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -7,6 +7,8 @@
 
 /** */
 
+import {V1EnvVarSource} from "@kubernetes/client-node/api";
+
 /**
  * The default shell for the job.
  */
@@ -147,7 +149,7 @@ export abstract class Job {
   /** tasks is a list of tasks run inside of the shell*/
   public tasks: string[];
   /** env is the environment variables for the job*/
-  public env: { [key: string]: string };
+  public env: { [key: string]: string | V1EnvVarSource };
   /** image is the container image to be run*/
   public image: string = brigadeImage;
   /** imageForcePull defines the container image pull policy: Always if true or IfNotPresent if false */

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -301,8 +301,30 @@ Properties:
 - `tasks`: An array of commands to run for this job
 - `shell`: The terminal emulator that job tasks will be executed under. By default,
   this is /bin/sh
-- `env`: Key/value pairs that will be injected into the environment. The key is
-  the variable name (`MY_VAR`), and the value is the string value (`foo`)
+- `env`: Key/value pairs or Kubernetes value references that will be injected into the environment. 
+  - If supplying key/value, the key is the variable name (`MY_VAR`), and the value is the string value (`foo`)
+  - If you are referencing existing Secrets or ConfigMaps in your Kubernetes cluster, the `env` object key
+    will be your secret name, and the value will be a Kubernetes reference object. `fieldRef`, `secretKeyRef`,
+    and `configMapKeyRef` are accepted. `resourceFieldRef` is technically supported but not advised, since resources
+    are not generally specified for Brigade jobs.
+  - Example: 
+    ```javascript
+    myJob.env = {
+        myOneOffSecret: "secret value",
+        myConfigReference: {
+            configMapKeyRef: {
+                name: "my-configmap",
+                key: "my-configmap-key"
+            }
+        },
+        mySecretReference: {
+            secretKeyRef: {
+                name: "my-secret",
+                key: "my-secret-key"
+            }
+        }
+    }
+    ```
 
 It is common to pass data from the `e.env` Event object into the Job object as is appropriate:
 

--- a/docs/topics/secrets.md
+++ b/docs/topics/secrets.md
@@ -103,7 +103,7 @@ to the `Job.env`?**
 Brigade is designed to use off-the-shelf Docker images. In the examples above, we used the
 `alpine:3.4` image straight from DockerHub. We wouldn't want to just automatically pass
 all of our information straight into that container. For starters, doing so might
-inadvertantly override an existing environment variable of the same name. More
+inadvertently override an existing environment variable of the same name. More
 importantly, the data might get misused or unintentionally exposed by the container.
 
 So we err on the side of safety.
@@ -114,8 +114,11 @@ We use Kubernetes Secrets for holding sensitive data. As encrypted Secrets are
 adopted into Kubernetes, we plan to support them. However, the present stable
 version of Kubernetes Secrets only Base64-encodes data.
 
-Our present recomendation is for Brigade developers to fetch the secret directly from a
+Our present recommendation is for Brigade developers to fetch the secret directly from a
 trusted key store such as Vault.
+
+Alternatively, you could use `secretKeyRef` to reference existing secrets already in your
+Kubernetes cluster.
 
 **I don't want to use Helm to manage my project/secrets. Can I do it manually?**
 


### PR DESCRIPTION
Currently, `Job`s in `brigade.js` files can only have key/value pairs in the `env` object. This means that accessing any secrets either needs to dynamically pulled from a storage system like Vault inside the container, or needs to be saved directly in the project in a `values.yaml` file that can't be committed to git due to containing secrets.  Many clusters will already contain a set of secrets for use across a number of deployments, especially if Brigade is being used for CI--many CI pipelines will reuse the same set of secrets.

This PR allows `secretKeyRef`, `configMapKeyRef`, and the other Kubernetes value references to be used in a job's `env` object.  This also comes with documentation updates and passing tests.  We are using this code right now internally and it works fine.

Note:
The one line I'm uncertain of is [this one](https://github.com/Azure/brigade/pull/396/files#diff-d54f19b6bbea870b89fa594044af83d9R214); ideally I'd like a better way to detect the type of the object that's being passed beyond just "is it a string or not," but unfortunately that pushes the boundaries of my Typescript knowledge.  I'm hoping someone on the Brigade team can advise on the best way to handle that.