### PR TITLE
feat(brig): add brig container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/brig/rootfs/brig
 /brigade-api/rootfs/brigade-api
 /brigade-controller/rootfs/brigade-controller
 /brigade-cr-gateway/rootfs/brigade-cr-gateway

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ DOCKER_REGISTRY    ?= deis
 DOCKER_BUILD_FLAGS :=
 LDFLAGS            :=
 
-BINS        = brigade-api brigade-controller brigade-github-gateway brig brigade-cr-gateway brigade-vacuum
-IMAGES      = brigade-api brigade-controller brigade-github-gateway brigade-worker git-sidecar brigade-cr-gateway brigade-vacuum
-DOCKER_BINS = brigade-api brigade-controller brigade-github-gateway brigade-cr-gateway brigade-vacuum
+BINS        = brigade-api brigade-controller brigade-github-gateway brigade-cr-gateway brigade-vacuum brig
+IMAGES      = brigade-api brigade-controller brigade-github-gateway brigade-cr-gateway brigade-vacuum brig brigade-worker git-sidecar
 
 GIT_TAG   = $(shell git describe --tags --always 2>/dev/null)
 VERSION   ?= ${GIT_TAG}
@@ -26,7 +25,7 @@ $(BINS): vendor
 	go build -ldflags '$(LDFLAGS)' -o bin/$@ ./$@/cmd/$@
 
 # Cross-compile for Docker+Linux
-build-docker-bins: $(addsuffix -docker-bin,$(DOCKER_BINS))
+build-docker-bins: $(addsuffix -docker-bin,$(BINS))
 
 %-docker-bin: vendor
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o ./$*/rootfs/$* ./$*/cmd/$*

--- a/brig/Dockerfile
+++ b/brig/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+
+COPY rootfs/brig /usr/bin/brig
+
+CMD /usr/bin/brig

--- a/brig/rootfs/README.md
+++ b/brig/rootfs/README.md
@@ -1,0 +1,3 @@
+# Brig Docker
+
+This is a Dockerized version of Brig.


### PR DESCRIPTION
This adds the necessary Dockerfile and Makefile changes so that we can
also build a containerized Brig, which is necessary for our CronJob
gateway.