### PR TITLE
docs(README): add brigade-cron gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This will show you the detailed output of running your `brigade.js` script's
   - [GitLab events](https://github.com/lukepatrick/brigade-gitlab-gateway): Gateway Support for GitLab repositories
   - [Kubernetes events](https://github.com/azure/brigade-k8s-gateway): Gateway that listens to Kubernetes event stream
   - [Event Grid gateway](https://github.com/radu-matei/brigade-eventgrid-gateway)" Gateway for Azure Event Grid events
+  - [Cron Gateway](https://github.com/technosophos/brigade-cron): Schedule events to run at a particular time
   - [Trello and Generic Webhooks](https://github.com/technosophos/brigade-trello): Experimental gateway for Trello and for generic webhooks
 
 ## Brigade :heart: Developers


### PR DESCRIPTION
This adds a link to Brigade-Cron.

(Submitted via GitHub editor)