### PR TITLE
feat(brig): Allow selection of log level to print (-l)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,7 +9,12 @@
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date"
+  ]
   revision = "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
   version = "v8.0.0"
 
@@ -43,12 +48,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/docker/spdystream"
-  packages = [".","spdy"]
+  packages = [
+    ".",
+    "spdy"
+  ]
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "ff4f55a206334ef123e4f79bbf348980da81ca46"
 
 [[projects]]
@@ -70,7 +81,11 @@
 
 [[projects]]
   name = "github.com/gin-gonic/gin"
-  packages = ["binding","json","render"]
+  packages = [
+    "binding",
+    "json",
+    "render"
+  ]
   revision = "d39ed41ab3795346f5f843ec31bc0138be07eaab"
 
 [[projects]]
@@ -95,7 +110,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 
 [[projects]]
@@ -105,7 +123,13 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
 
 [[projects]]
@@ -132,28 +156,50 @@
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
   revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
 
 [[projects]]
   name = "github.com/gophercloud/gophercloud"
-  packages = [".","openstack","openstack/identity/v2/tenants","openstack/identity/v2/tokens","openstack/identity/v3/tokens","openstack/utils","pagination"]
+  packages = [
+    ".",
+    "openstack",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/utils",
+    "pagination"
+  ]
   revision = "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
 
 [[projects]]
   branch = "master"
   name = "github.com/gosuri/uitable"
-  packages = [".","util/strutil","util/wordwrap"]
+  packages = [
+    ".",
+    "util/strutil",
+    "util/wordwrap"
+  ]
   revision = "36ee7e946282a3fb1cfecd476ddc9b35d8847e42"
 
 [[projects]]
   name = "github.com/gregjones/httpcache"
-  packages = [".","diskcache"]
+  packages = [
+    ".",
+    "diskcache"
+  ]
   revision = "787624de3eb7bd915c329cba748687a3b22666a6"
 
 [[projects]]
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
 
 [[projects]]
@@ -186,7 +232,11 @@
 
 [[projects]]
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "d5b7844b561a7bc640052f1b935f7b800330d7e0"
 
 [[projects]]
@@ -241,27 +291,71 @@
 
 [[projects]]
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex"
+  ]
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
   revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
 
 [[projects]]
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["cases","internal","internal/gen","internal/tag","internal/triegen","internal/ucd","language","runes","secure/bidirule","secure/precis","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "cases",
+    "internal",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "runes",
+    "secure/bidirule",
+    "secure/precis",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "b19bf474d317b857955b12035d2c5acb57ce8b01"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "12d5545dc1cfa6047a286d5e853841b6471f4c19"
 
 [[projects]]
@@ -289,19 +383,170 @@
 
 [[projects]]
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1beta1"]
+  packages = [
+    "admissionregistration/v1alpha1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1beta1"
+  ]
   revision = "6c6dac0277229b9e9578c5ca3f74a4345d35cdc2"
   version = "kubernetes-1.8.1"
 
 [[projects]]
   branch = "release-1.8"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/internalversion","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/httpstream","pkg/util/httpstream/spdy","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/netutil","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1alpha1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/conversion/unstructured",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/netutil",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "019ae5ada31de202164b118aee88ee2d14075c31"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","plugin/pkg/client/auth","plugin/pkg/client/auth/azure","plugin/pkg/client/auth/gcp","plugin/pkg/client/auth/oidc","plugin/pkg/client/auth/openstack","rest","rest/watch","testing","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/portforward","tools/reference","transport","transport/spdy","util/cert","util/flowcontrol","util/homedir","util/integer","util/jsonpath","util/workqueue"]
+  packages = [
+    "discovery",
+    "discovery/fake",
+    "kubernetes",
+    "kubernetes/fake",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1alpha1/fake",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta1/fake",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/apps/v1beta2/fake",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1/fake",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authentication/v1beta1/fake",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1/fake",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/authorization/v1beta1/fake",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v1/fake",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta1/fake",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1/fake",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v1beta1/fake",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/batch/v2alpha1/fake",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/certificates/v1beta1/fake",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/core/v1/fake",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/extensions/v1beta1/fake",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1/fake",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/policy/v1beta1/fake",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1/fake",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1alpha1/fake",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/rbac/v1beta1/fake",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1alpha1/fake",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1/fake",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1/fake",
+    "kubernetes/typed/storage/v1beta1",
+    "kubernetes/typed/storage/v1beta1/fake",
+    "pkg/version",
+    "plugin/pkg/client/auth",
+    "plugin/pkg/client/auth/azure",
+    "plugin/pkg/client/auth/gcp",
+    "plugin/pkg/client/auth/oidc",
+    "plugin/pkg/client/auth/openstack",
+    "rest",
+    "rest/watch",
+    "testing",
+    "third_party/forked/golang/template",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/pager",
+    "tools/portforward",
+    "tools/reference",
+    "transport",
+    "transport/spdy",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+    "util/jsonpath",
+    "util/workqueue"
+  ]
   revision = "2ae454230481a7cb5544325e12ad7658ecccd19b"
   version = "v5.0.1"
 
@@ -313,6 +558,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "db97ceb6bc5a1a56468b45f57264a0a4f517586d41533ce8b16138a50a033156"
+  inputs-digest = "cc6b2287126a9cd12d7a88c9d30cb053ebc57029d6ea79c6889e2c2035839faa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/brig/cmd/brig/commands/app.go
+++ b/brig/cmd/brig/commands/app.go
@@ -13,7 +13,7 @@ import (
 const mainUsage = `Interact with the Brigade cluster service.
 
 Brigade is a tool for scripting cluster workflows, and 'brig' is the command
-line client for intearcting with Brigade.
+line client for interacting with Brigade.
 
 The most common use for this tool is to send a Brigade JavaScript file to the
 cluster for execution. This is done with the 'brigade run' command.

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -202,6 +202,7 @@ func (c *Controller) workerEnv(project, build *v1.Secret) []v1.EnvVar {
 		{Name: "BRIGADE_EVENT_PROVIDER", Value: sv.String("event_provider")},
 		{Name: "BRIGADE_EVENT_TYPE", Value: sv.String("event_type")},
 		{Name: "BRIGADE_PROJECT_ID", Value: sv.String("project_id")},
+		{Name: "BRIGADE_LOG_LEVEL", Value: sv.String("log_level")},
 		{Name: "BRIGADE_REMOTE_URL", Value: string(project.Data["cloneURL"])},
 		{Name: "BRIGADE_WORKSPACE", Value: sidecarVolumePath},
 		{
@@ -223,7 +224,7 @@ func (c *Controller) workerEnv(project, build *v1.Secret) []v1.EnvVar {
 	return env
 }
 
-// secretRef generate a SeccretKeyRef env var entry if `key` is present in `secret`.
+// secretRef generate a SecretKeyRef env var entry if `key` is present in `secret`.
 // If the key does not exist a name/value pair is returned with an empty value
 func secretRef(key string, secret *v1.Secret) *v1.EnvVarSource {
 	trueVal := true

--- a/brigade-worker/src/app.ts
+++ b/brigade-worker/src/app.ts
@@ -76,6 +76,7 @@ export class App {
    */
   public run(e: events.BrigadeEvent): Promise<boolean> {
     this.lastEvent = e;
+    this.logger.logLevel = e.logLevel;
 
     // This closure destroys storage for us. It is called by event handlers.
     let destroyStorage = () => {
@@ -144,6 +145,7 @@ export class App {
         type: "after",
         provider: "brigade",
         revision: e.revision,
+        logLevel: e.logLevel,
         cause: {
           event: e,
           trigger: code == 0 ? "success" : "failure"
@@ -193,6 +195,7 @@ export class App {
       type: "error",
       provider: "brigade",
       revision: this.lastEvent.revision,
+      logLevel: this.lastEvent.logLevel,
       cause: {
         event: this.lastEvent,
         reason: reason,

--- a/brigade-worker/src/events.ts
+++ b/brigade-worker/src/events.ts
@@ -7,6 +7,7 @@
  */
 
 import { EventEmitter } from "events";
+import { LogLevel } from "./logger";
 
 /**
  * BrigadeEvent describes an event.
@@ -62,6 +63,13 @@ export class BrigadeEvent {
    * JSON as a string that must be decoded with something like `JSON.parse()`
    */
   payload?: any;
+
+  /**
+   * logLevel is the level at which the Brigade worker will print logs to console.
+   * Permitted values are the names of the logLevel enum.
+   */
+  logLevel: LogLevel;
+
   cause?: Cause;
 }
 

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -31,14 +31,15 @@ import * as ulid from "ulid";
 
 import * as events from "./events";
 import { App } from "./app";
-import { Logger, ContextLogger } from "./logger";
+import {ContextLogger, LogLevel} from "./logger";
 
 import { options } from "./k8s";
 
 // This is a side-effect import.
 import "./brigade";
 
-const logger = new ContextLogger();
+const logLevel = LogLevel[process.env.BRIGADE_LOG_LEVEL || 'LOG'];
+const logger = new ContextLogger([], logLevel);
 
 const version = require("../package.json").version;
 logger.log(`brigade-worker version: ${version}`);
@@ -62,7 +63,8 @@ let e: events.BrigadeEvent = {
   revision: {
     commit: process.env.BRIGADE_COMMIT_ID,
     ref: process.env.BRIGADE_COMMIT_REF || "refs/heads/master"
-  }
+  },
+  logLevel: logLevel,
 };
 
 try {

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -6,7 +6,7 @@
 
 import * as kubernetes from "@kubernetes/client-node";
 import * as jobs from "./job";
-import { Logger, ContextLogger } from "./logger";
+import { LogLevel, ContextLogger } from "./logger";
 import { BrigadeEvent, Project } from "./events";
 
 // The internals for running tasks. This must be loaded before any of the
@@ -20,8 +20,6 @@ import { BrigadeEvent, Project } from "./events";
 const expiresInMSec = 1000 * 60 * 60 * 24 * 30;
 
 const defaultClient = kubernetes.Config.defaultClient();
-
-const logger = new ContextLogger("k8s");
 
 /**
  * options is the set of configuration options for the library.
@@ -70,6 +68,7 @@ export class BuildStorage {
   proj: Project;
   name: string;
   build: string;
+  logger: ContextLogger;
 
   /**
    * create initializes a new PVC for storing data.
@@ -82,8 +81,10 @@ export class BuildStorage {
     this.proj = project;
     this.name = e.workerID.toLowerCase();
     this.build = e.buildID;
+    this.logger = new ContextLogger("k8s", e.logLevel);
+
     let pvc = this.buildPVC(size);
-    logger.log(`Creating PVC named ${this.name}`);
+    this.logger.log(`Creating PVC named ${this.name}`);
     return defaultClient
       .createNamespacedPersistentVolumeClaim(
         this.proj.kubernetes.namespace,
@@ -97,7 +98,7 @@ export class BuildStorage {
    * destroy deletes the PVC.
    */
   public destroy(): Promise<boolean> {
-    logger.log(`Destroying PVC named ${this.name}`);
+    this.logger.log(`Destroying PVC named ${this.name}`);
     let opts = new kubernetes.V1DeleteOptions();
     return defaultClient
       .deleteNamespacedPersistentVolumeClaim(
@@ -168,11 +169,13 @@ export class JobRunner implements jobs.JobRunner {
   client: kubernetes.Core_v1Api;
   options: KubernetesOptions;
   serviceAccount: string;
+  logger: ContextLogger;
 
   constructor(job: jobs.Job, e: BrigadeEvent, project: Project) {
     this.options = Object.assign({}, options);
 
     this.event = e;
+    this.logger = new ContextLogger("k8s", e.logLevel);
     this.job = job;
     this.project = project;
     this.client = defaultClient;
@@ -375,11 +378,11 @@ export class JobRunner implements jobs.JobRunner {
     return new Promise((resolve, reject) => {
       pvcPromise
         .then(() => {
-          logger.log("Creating secret " + this.secret.metadata.name);
+          this.logger.log("Creating secret " + this.secret.metadata.name);
           return k.createNamespacedSecret(ns, this.secret);
         })
         .then(result => {
-          logger.log("Creating pod " + this.runner.metadata.name);
+          this.logger.log("Creating pod " + this.runner.metadata.name);
           // Once namespace creation has been accepted, we create the pod.
           return k.createNamespacedPod(ns, this.runner);
         })
@@ -387,7 +390,7 @@ export class JobRunner implements jobs.JobRunner {
           resolve(this);
         })
         .catch(reason => {
-          logger.error(reason);
+          this.logger.error(reason);
           reject(reason);
         });
     });
@@ -408,7 +411,7 @@ export class JobRunner implements jobs.JobRunner {
         resolve("no cache requested");
       } else {
         let cname = this.cacheName();
-        logger.log(`looking up ${ns}/${cname}`);
+        this.logger.log(`looking up ${ns}/${cname}`);
         k
           .readNamespacedPersistentVolumeClaim(cname, ns)
           .then(result => {
@@ -416,16 +419,16 @@ export class JobRunner implements jobs.JobRunner {
           })
           .catch(result => {
             // TODO: check if cache exists.
-            logger.log(`Creating Job Cache PVC ${cname}`);
+            this.logger.log(`Creating Job Cache PVC ${cname}`);
             return k
               .createNamespacedPersistentVolumeClaim(ns, this.pvc)
               .then((result, newPVC) => {
-                logger.log("created cache");
+                this.logger.log("created cache");
                 resolve("created job cache");
               });
           })
           .catch(err => {
-            logger.error(err);
+            this.logger.error(err);
             reject(err);
           });
       }
@@ -444,7 +447,7 @@ export class JobRunner implements jobs.JobRunner {
     // This is a handle to clear the setTimeout when the promise is fulfilled.
     let waiter;
 
-    logger.log(`Timeout set at ${timeout}`);
+    this.logger.log(`Timeout set at ${timeout}`);
 
     // At intervals, poll the Kubernetes server and get the pod phase. If the
     // phase is Succeeded or Failed, bail out. Otherwise, keep polling.
@@ -464,7 +467,7 @@ export class JobRunner implements jobs.JobRunner {
           .then(response => {
             let pod = response.body;
             if (pod.status == undefined) {
-              logger.log("Pod not yet scheduled");
+              this.logger.log("Pod not yet scheduled");
               return;
             }
             let phase = pod.status.phase;
@@ -490,12 +493,12 @@ export class JobRunner implements jobs.JobRunner {
                     ns,
                     new kubernetes.V1DeleteOptions()
                   )
-                  .catch(e => logger.error(e));
+                  .catch(e => this.logger.error(e));
                 clearTimers();
                 reject(new Error(cs[0].state.waiting.message));
               }
             }
-            logger.log(
+            this.logger.log(
               `${pod.metadata.namespace}/${pod.metadata.name} phase ${
                 pod.status.phase
               }`
@@ -503,8 +506,8 @@ export class JobRunner implements jobs.JobRunner {
             // In all other cases we fall through and let the fn be run again.
           })
           .catch(reason => {
-            logger.error("failed pod lookup");
-            logger.error(reason);
+            this.logger.error("failed pod lookup");
+            this.logger.error(reason);
             clearTimers();
             reject(reason);
           });
@@ -591,7 +594,8 @@ function sidecarSpec(
       envVar("BRIGADE_REMOTE_URL", project.repo.cloneURL),
       envVar("BRIGADE_WORKSPACE", local),
       envVar("BRIGADE_PROJECT_NAMESPACE", project.kubernetes.namespace),
-      envVar("BRIGADE_SUBMODULES", initGitSubmodules.toString())
+      envVar("BRIGADE_SUBMODULES", initGitSubmodules.toString()),
+      envVar("BRIGADE_LOG_LEVEL", LogLevel[e.logLevel]),
     ]);
   spec.image = imageTag;
   (spec.imagePullPolicy = "IfNotPresent"),

--- a/brigade-worker/src/logger.ts
+++ b/brigade-worker/src/logger.ts
@@ -9,20 +9,51 @@ const pe = new PrettyError()
   .alias(rootPath, ".");
 pe.start();
 
+export enum LogLevel {
+  ALL = 0,
+  LOG,
+  INFO,
+  WARN,
+  ERROR,
+  NONE,
+}
+
 export interface Logger {
+  logLevel: LogLevel;
   error(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+  info(message?: any, ...optionalParams: any[]): void;
   log(message?: any, ...optionalParams: any[]): void;
 }
 
 export class ContextLogger implements Logger {
   context: string;
-  constructor(...ctx: string[]) {
+  logLevel: LogLevel;
+  constructor(ctx: string[] | string = [], logLevel = LogLevel.LOG) {
+    if (typeof ctx === 'string') {
+      ctx = [ctx];
+    }
     this.context = `[${new Array("brigade", ...ctx).join(":")}]`;
+    this.logLevel = logLevel;
   }
   error(message?: any, ...optionalParams: any[]): void {
-    console.error(this.context, message, ...optionalParams);
+    if (LogLevel.ERROR >= this.logLevel) {
+      console.error(this.context, message, ...optionalParams);
+    }
+  }
+  warn(message?: any, ...optionalParams: any[]): void {
+    if (LogLevel.WARN >= this.logLevel) {
+      console.warn(this.context, message, ...optionalParams);
+    }
+  }
+  info(message?: any, ...optionalParams: any[]): void {
+    if (LogLevel.INFO >= this.logLevel) {
+      console.info(this.context, message, ...optionalParams);
+    }
   }
   log(message?: any, ...optionalParams: any[]): void {
-    console.log(this.context, message, ...optionalParams);
+    if (LogLevel.LOG >= this.logLevel) {
+      console.log(this.context, message, ...optionalParams);
+    }
   }
 }

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -177,12 +177,16 @@ describe("k8s", function() {
         it("attaches key to pod", function() {
           let jr = new k8s.JobRunner(j, e, p);
           let sidecar = jr.runner.spec.initContainers[0];
-          assert.equal(sidecar.env.length, 13);
-          assert.equal(
-            sidecar.env[11].name,
-            "BRIGADE_REPO_KEY",
-            "Has BRIGADE REPO KEY as param"
-          );
+          assert.equal(sidecar.env.length, 14);
+
+          let hasBrigadeRepoKey : boolean = false;
+          for (let i of sidecar.env) {
+            if (i.name === "BRIGADE_REPO_KEY") {
+              hasBrigadeRepoKey = true;
+              break;
+            }
+          }
+          assert.isTrue(hasBrigadeRepoKey, "Has BRIGADE REPO KEY as param");
         });
       });
       context("when mount path is supplied", function() {

--- a/pkg/brigade/build.go
+++ b/pkg/brigade/build.go
@@ -23,6 +23,9 @@ type Build struct {
 	// reflect a "roll-up" of the job.
 	// This property is not guaranteed to be set, and may be nil.
 	Worker *Worker `json:"worker"`
+	// LogLevel determines what level of logging from the Javascript
+	// to print to console.
+	LogLevel string `json:"log_level,omitempty"`
 }
 
 // Revision describes a vcs revision.

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -65,6 +65,7 @@ func (s *store) CreateBuild(build *brigade.Build) error {
 			"event_provider": build.Provider,
 			"event_type":     build.Type,
 			"project_id":     build.ProjectID,
+			"log_level":      build.LogLevel,
 		},
 	}
 

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -25,6 +25,7 @@ func TestNewBuildFromSecret(t *testing.T) {
 			"script":         []byte("ohai"),
 			"commit_id":      []byte("abc123"),
 			"commit_ref":     []byte("refs/heads/master"),
+			"log_level":      []byte("LOG"),
 		},
 	}
 	build := NewBuildFromSecret(secret)


### PR DESCRIPTION
The `brig` CLI is very verbose in its logging.  While this is helpful for developers, it makes Brigade tough to integrate into other systems that need to offer more limited and meaningful output to users.

This PR adds an `-l` option to `brig`, letting the caller specify the log levels to print to stdout.  The permitted log levels are `ALL`, `LOG`, `INFO`, `WARN`, `ERROR`, or `NONE`, and all logs at levels equal to or above the level specified are printed.  The log level specified by the CLI is passed from the CLI to the controller, is added to the build's `Secret`, and is passed to the worker container.

I ran all of the Go and Typescript unit tests and ran a live build with a specified log level against our staging Kubernetes cluster.

Edit: Turns out this is slightly less necessary after #399, but still useful. We're using it at `logger.info()` to only print out necessary output to users.