### PR TITLE
fix(docs): Update "timeout" documentation

### DIFF
--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -177,7 +177,7 @@ Properties of `Job`
 - `image: string`: The container image to run
 - `imagePullSecrets: string`: The names of the pull secrets (for pulling images from a secure remote repository)
 - `mountPath: string`: The path where any resources should be mounted (e.g. where a Git repository will be cloned) (defaults to `/src`)
-- `timeout: number`: Time to wait, in seconds, before the job is marked "failed"
+- `timeout: number`: Time to wait, in milliseconds, before the job is marked "failed"
 - `useSource: bool`: If false, no external resource will be loaded (e.g. no git clone will be performed)
 - `privileged: bool`: If this is true, the job will be executed in privileged mode, which allows it to do things like access a Docker socket. EXPERTS ONLY.
 - `host: JobHost`: Preferences for the host that runs the job.


### PR DESCRIPTION
The Javascript docs say that `timeout` on `Job` is in seconds.  It appears to actually be in milliseconds, from looking at the code and my own experience adding timeouts.