### PR TITLE
fix(worker): allow jobs during error handler

### DIFF
--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -31,14 +31,14 @@ import * as ulid from "ulid";
 
 import * as events from "./events";
 import { App } from "./app";
-import {ContextLogger, LogLevel} from "./logger";
+import { ContextLogger, LogLevel } from "./logger";
 
 import { options } from "./k8s";
 
 // This is a side-effect import.
 import "./brigade";
 
-const logLevel = LogLevel[process.env.BRIGADE_LOG_LEVEL || 'LOG'];
+const logLevel = LogLevel[process.env.BRIGADE_LOG_LEVEL || "LOG"];
 const logger = new ContextLogger([], logLevel);
 
 const version = require("../package.json").version;
@@ -64,7 +64,7 @@ let e: events.BrigadeEvent = {
     commit: process.env.BRIGADE_COMMIT_ID,
     ref: process.env.BRIGADE_COMMIT_REF || "refs/heads/master"
   },
-  logLevel: logLevel,
+  logLevel: logLevel
 };
 
 try {

--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -7,7 +7,7 @@
 
 /** */
 
-import {V1EnvVarSource} from "@kubernetes/client-node/api";
+import { V1EnvVarSource } from "@kubernetes/client-node/api";
 
 /**
  * The default shell for the job.

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -215,7 +215,7 @@ export class JobRunner implements jobs.JobRunner {
     for (let key in job.env) {
       let val = job.env[key];
 
-      if (typeof val === 'string') {
+      if (typeof val === "string") {
         // For environmental variables that are submitted as strings,
         // add to the job's secret and add a reference.
 
@@ -235,8 +235,8 @@ export class JobRunner implements jobs.JobRunner {
         // add the reference to the env var list.
 
         envVars.push({
-            name: key,
-            valueFrom: val
+          name: key,
+          valueFrom: val
         } as kubernetes.V1EnvVar);
       }
     }
@@ -608,7 +608,7 @@ function sidecarSpec(
       envVar("BRIGADE_WORKSPACE", local),
       envVar("BRIGADE_PROJECT_NAMESPACE", project.kubernetes.namespace),
       envVar("BRIGADE_SUBMODULES", initGitSubmodules.toString()),
-      envVar("BRIGADE_LOG_LEVEL", LogLevel[e.logLevel]),
+      envVar("BRIGADE_LOG_LEVEL", LogLevel[e.logLevel])
     ]);
   spec.image = imageTag;
   (spec.imagePullPolicy = "IfNotPresent"),
@@ -664,7 +664,10 @@ function newRunnerPod(
   c1.securityContext = new kubernetes.V1SecurityContext();
   if (resourceRequests.cpu && resourceRequests.memory) {
     let resourceRequirements = new kubernetes.V1ResourceRequirements();
-    resourceRequirements.requests = {"cpu": resourceRequests.cpu, "memory": resourceRequests.memory }
+    resourceRequirements.requests = {
+      cpu: resourceRequests.cpu,
+      memory: resourceRequests.memory
+    };
     c1.resources = resourceRequirements;
   }
   pod.spec = new kubernetes.V1PodSpec();

--- a/brigade-worker/src/logger.ts
+++ b/brigade-worker/src/logger.ts
@@ -15,7 +15,7 @@ export enum LogLevel {
   INFO,
   WARN,
   ERROR,
-  NONE,
+  NONE
 }
 
 export interface Logger {
@@ -30,7 +30,7 @@ export class ContextLogger implements Logger {
   context: string;
   logLevel: LogLevel;
   constructor(ctx: string[] | string = [], logLevel = LogLevel.LOG) {
-    if (typeof ctx === 'string') {
+    if (typeof ctx === "string") {
       ctx = [ctx];
     }
     this.context = `[${new Array("brigade", ...ctx).join(":")}]`;

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -27,7 +27,7 @@ describe("job", function() {
         "-ab", // no leading dash
         "a_b", // underscore is illegal
         "ab.", // trailing dot is illegal
-        "A-B", // Capitals are illegal
+        "A-B" // Capitals are illegal
       ];
       for (let n of illegal) {
         assert.isFalse(jobNameIsValid(n), "tested " + n);

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -94,7 +94,7 @@ describe("k8s", function() {
         assert.property(jr.secret.data, "main.sh");
       });
       context("when env vars are specified", function() {
-        context("as data", function () {
+        context("as data", function() {
           beforeEach(function() {
             j.env = { one: "first", two: "second" };
           });
@@ -115,36 +115,36 @@ describe("k8s", function() {
             assert.equal(found, 2);
           });
         });
-        context("as references", function () {
-          beforeEach(function () {
+        context("as references", function() {
+          beforeEach(function() {
             j.env = {
               one: {
                 secretKeyRef: {
-                  name: 'secret-name',
-                  key: 'secret-key'
+                  name: "secret-name",
+                  key: "secret-key"
                 }
               } as kubernetes.V1EnvVarSource,
               two: {
                 configMapKeyRef: {
-                  name: 'configmap-name',
-                  key: 'configmap-key'
+                  name: "configmap-name",
+                  key: "configmap-key"
                 }
               } as kubernetes.V1EnvVarSource
             };
           });
-          it("sets them on the pod", function () {
-              let jr = new k8s.JobRunner(j, e, p);
-              let found = 0;
+          it("sets them on the pod", function() {
+            let jr = new k8s.JobRunner(j, e, p);
+            let found = 0;
 
-              for (let k in j.env) {
-                for (let env of jr.runner.spec.containers[0].env) {
-                  if (env.name == k) {
-                    assert.equal(env.valueFrom, j.env[k]);
-                    found++;
-                  }
+            for (let k in j.env) {
+              for (let env of jr.runner.spec.containers[0].env) {
+                if (env.name == k) {
+                  assert.equal(env.valueFrom, j.env[k]);
+                  found++;
                 }
               }
-              assert.equal(found, 2);
+            }
+            assert.equal(found, 2);
           });
         });
       });
@@ -213,7 +213,7 @@ describe("k8s", function() {
           let sidecar = jr.runner.spec.initContainers[0];
           assert.equal(sidecar.env.length, 14);
 
-          let hasBrigadeRepoKey : boolean = false;
+          let hasBrigadeRepoKey: boolean = false;
           for (let i of sidecar.env) {
             if (i.name === "BRIGADE_REPO_KEY") {
               hasBrigadeRepoKey = true;


### PR DESCRIPTION
The error handler was not waiting for other events to finish. This
removes the process error code handling to the "exit" event, and allows
the "error" event to schedule jobs and other things that will require a
next-tick. It also intentionally bypasses the "after" event once an
error code is set. This ensures that if "error" triggers, "after" won't.

Closes #364