### PR TITLE
feat(brigade.js): Retrieve logs from Job run

### DIFF
--- a/brigade-worker/src/brigadier.ts
+++ b/brigade-worker/src/brigadier.ts
@@ -49,15 +49,21 @@ export function fire(e: eventsImpl.BrigadeEvent, p: eventsImpl.Project) {
  * executed as-is.
  */
 export class Job extends jobImpl.Job {
+  jr: JobRunner;
+
   run(): Promise<jobImpl.Result> {
-    let jr = new JobRunner(this, currentEvent, currentProject);
-    this._podName = jr.name;
-    return jr.run().catch(err => {
+    this.jr = new JobRunner(this, currentEvent, currentProject);
+    this._podName = this.jr.name;
+    return this.jr.run().catch(err => {
       // Wrap the message to give clear context.
       console.error(err);
-      let msg = `job ${this.name}(${jr.name}): ${err}`;
+      let msg = `job ${this.name}(${this.jr.name}): ${err}`;
       return Promise.reject(new Error(msg));
     });
+  }
+
+  logs(): Promise<string> {
+    return this.jr.logs();
   }
 }
 

--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -255,6 +255,9 @@ export abstract class Job {
 
   /** run executes the job and then */
   public abstract run(): Promise<Result>;
+
+  /** logs retrieves the logs (so far) from the job run */
+  public abstract logs(): Promise<string>;
 }
 
 /**

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -360,6 +360,15 @@ export class JobRunner implements jobs.JobRunner {
     }`.toLowerCase();
   }
 
+  public logs(): Promise<string> {
+    let podName = this.name;
+    let k = this.client;
+    let ns = this.project.kubernetes.namespace;
+    return k.readNamespacedPodLog(podName, ns).then(result => {
+      return result.body;
+    });
+  }
+
   /**
    * run starts a job and then waits until it is running.
    *
@@ -367,16 +376,13 @@ export class JobRunner implements jobs.JobRunner {
    * Success (resolve) or Failure (reject)
    */
   public run(): Promise<jobs.Result> {
-    let podName = this.name;
-    let k = this.client;
-    let ns = this.project.kubernetes.namespace;
     return this.start()
       .then(r => r.wait())
       .then(r => {
-        return k.readNamespacedPodLog(podName, ns);
+        return this.logs();
       })
       .then(response => {
-        return new K8sResult(response.body);
+        return new K8sResult(response);
       });
   }
 

--- a/brigade-worker/test/brigadier.ts
+++ b/brigade-worker/test/brigadier.ts
@@ -62,6 +62,16 @@ describe("brigadier", function() {
           done();
         });
       });
+      it("gathers the logs after the run", function(done) {
+        let j1 = new mock.MockJob("first");
+        j1.fail = true;
+        j1.run().catch((res: jobImpl.Result) => {
+          j1.logs().then((output: string) => {
+            assert.equal(output, "These are the logs showing failure.");
+            done();
+          });
+        });
+      });
       context("when job fails", function() {
         it("stops processing with an error", function(done) {
           let j1 = new mock.MockJob("first");

--- a/brigade-worker/test/mock.ts
+++ b/brigade-worker/test/mock.ts
@@ -69,6 +69,22 @@ export class MockJob extends Job {
       setTimeout(resolve(new MockResult(this.name)), delay);
     });
   }
+  public logs(): Promise<string> {
+    let fail = this.fail;
+    let delay = this.delay;
+    this._podName = "generated-fake-job-name-2";
+    return new Promise((resolve, reject) => {
+      if (fail) {
+        setTimeout(() => {
+          resolve(`These are the logs showing failure.`);
+        }, delay);
+        return;
+      }
+      setTimeout(() => {
+        resolve(`These are the logs showing successful completion.`);
+      }, delay);
+    });
+  }
 }
 
 export class MockBuildStorage {


### PR DESCRIPTION
We needed a way to output the logs of a Job after the fact&mdash;in particular, for reporting on failed jobs.  This adds a `logs()` method to the Typescript `Job`.

Note that this does not seem to be fully working, even though the tests pass.  When I run this code:
```javascript
    let slack = new Job("slack-notify", "technosophos/slack-notify:latest", ["/slack-notify"]);
    slack.storage.enabled = false;
    slack.useSource = false;
    slack.env = {
        SLACK_WEBHOOK: project.secrets.SLACK_WEBHOOK,
        SLACK_COLOR: "red",
        SLACK_CHANNEL: "brigade-failures",
        SLACK_TITLE: `Build failure`,
        SLACK_MESSAGE: `Build ${event.buildID} failed to build.`
    };

    await slack.run()
    let logs = await slack.logs();
    console.info(`This is a test: ${logs}`);
```

I get this output:
```
Event created. Waiting for worker pod named "brigade-worker-01cav4jcjea8wzqsvs1bycedeq".
Started build 01cav4jcjea8wzqsvs1bycedeq as "brigade-worker-01cav4jcjea8wzqsvs1bycedeq"
prestart: src/brigade.js written
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c node --no-deprecation ./dist/index.js
Directory: /home/src
Output:
".
```