### PR TITLE
Add job annotations

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -217,6 +217,11 @@ export abstract class Job {
    */
   public docker: JobDockerMount;
 
+  /**
+   * pod annotations for the job
+   */
+  public annotations: { [key: string]: string; } = {};
+
   /** _podName is set by the runtime. It is the name of the pod.*/
   protected _podName: string;
 

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -193,7 +193,8 @@ export class JobRunner implements jobs.JobRunner {
       job.image,
       job.imageForcePull,
       this.serviceAccount,
-      job.resourceRequests
+      job.resourceRequests,
+      job.annotations
     );
 
     // Experimenting with setting a deadline field after which something
@@ -646,7 +647,8 @@ function newRunnerPod(
   brigadeImage: string,
   imageForcePull: boolean,
   serviceAccount: string,
-  resourceRequests: jobs.JobResourceRequest
+  resourceRequests: jobs.JobResourceRequest,
+  jobAnnotations: { [key: string]: string; }
 ): kubernetes.V1Pod {
   let pod = new kubernetes.V1Pod();
   pod.metadata = new kubernetes.V1ObjectMeta();
@@ -655,6 +657,7 @@ function newRunnerPod(
     heritage: "brigade",
     component: "job"
   };
+  pod.metadata.annotations = jobAnnotations;
 
   let c1 = new kubernetes.V1Container();
   c1.name = "brigaderun";

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -138,7 +138,7 @@ describe("job", function() {
       beforeEach(function() {
         j = new mock.MockJob("my-job");
       });
-      it("is a empty list that can be written", function() {
+      it("is an empty list that can be written", function() {
         assert.deepEqual(j.annotations, {});
         j.annotations['some_kubetoiam/thing'] = 'my/path';
         assert.deepEqual(j.annotations, { 'some_kubetoiam/thing': 'my/path' });

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -134,5 +134,15 @@ describe("job", function() {
         assert.isFalse(j.storage.enabled);
       });
     });
+    describe("#annotations", function() {
+      beforeEach(function() {
+        j = new mock.MockJob("my-job");
+      });
+      it("is a empty list that can be written", function() {
+        assert.deepEqual(j.annotations, {});
+        j.annotations['some_kubetoiam/thing'] = 'my/path';
+        assert.deepEqual(j.annotations, { 'some_kubetoiam/thing': 'my/path' });
+      });
+    });
   });
 });

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -189,7 +189,7 @@ describe("k8s", function() {
           let jr = new k8s.JobRunner(j, e, p);
           // Currently, annotations are only created if the init container
           // is specified.
-          assert.notProperty(jr.runner.metadata, "annotations");
+          assert.deepEqual(jr.runner.metadata.annotations, {});
         });
       });
       context("when no cloneURL is set", function() {
@@ -201,7 +201,7 @@ describe("k8s", function() {
           let jr = new k8s.JobRunner(j, e, p);
           // Currently, annotations are only created if the init container
           // is specified.
-          assert.notProperty(jr.runner.metadata, "annotations");
+          assert.deepEqual(jr.runner.metadata.annotations, {});
         });
       });
       context("when SSH key is provided", function() {


### PR DESCRIPTION
This adds the ability to add annotations to brigade job pods from the brigade.js brigade-worker.

We ran across the need for this to be able to run workloads in ec2 and take advantage of [kube2iam](https://github.com/jtblin/kube2iam#kubernetes-annotation), which needs an annotation.

I tested this in minikube, adding a dummy annotation to my brigade pod:

```javascript
  // Create a new job
  var node = new Job("copy-staging-db");

  // snip

  node.tasks = [
    'env',
    'hostname'
  ];

  node.annotations = {
    'test/annotation': "annotations/go/here"
  };

  // We're done configuring, so we run the job
  node.run(); 
```
and saw the annotation applied on the pod via the dashboard
![screen shot 2018-04-13 at 8 30 37 am](https://user-images.githubusercontent.com/259800/38744120-d074f9d4-3ef5-11e8-8d97-eefc4d5c6c64.png)

I'm not currently sure this adversely affects anything else - it doesnt seem like it does, the tests were testing to ensure that annotations were not set except for the init container, and those just changed to asserting an empty object.

Happy to answer any other questions.