### PR TITLE
Document imageForcePull

### DIFF
--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -143,7 +143,7 @@ Functionally, this is equivalent to the static `runEach` method.
 
 The `Job` class describes a job that can be run.
 
-#### constructor `new Job(name: string, image?: string, tasks?: string[]): Job`
+#### constructor `new Job(name: string, image?: string, tasks?: string[], imageForcePull?: boolean): Job`
 
 The constructor requires a `name` parameter, and this must be unique within your
 script. It must be composed of the characters a-z, A-Z, 0-9, and `-`. Additionally,
@@ -173,6 +173,7 @@ Properties of `Job`
 - `name: string`: The job name
 - `shell: string`: The shell in which to execute the tasks (`/bin/sh`)
 - `tasks: string[]`: Tasks to be run in the job, in order.
+- `imageForcePull: boolean`: Defines the container image pull policy: `Always` if `true` or `IfNotPresent` if `false` (defaults to `false`).
 - `env: {[key: string]:string}`: Name/value pairs of environment variables.
 - `image: string`: The container image to run
 - `imagePullSecrets: string`: The names of the pull secrets (for pulling images from a secure remote repository)


### PR DESCRIPTION
This feature was implemented here:

https://github.com/Azure/brigade/pull/168/files

But was not documented.

On a related note, should we file a story to auto-generate this documentation in the longer-term to help prevent this kinda thing?