### PR TITLE
feat(Job): add keepCommand option to Jobs

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -156,6 +156,10 @@ export abstract class Job {
   public name: string;
   /** shell that will be used by default in this job*/
   public shell: string = defaultShell;
+  /** keepCommand determines whether Brigade runs the job
+   *  with the default container command (entrypoint) or whether it overrides and
+   *  removes it.*/
+  public keepCommand: boolean = false;
   /** tasks is a list of tasks run inside of the shell*/
   public tasks: string[];
   /** env is the environment variables for the job*/

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -193,7 +193,8 @@ export class JobRunner implements jobs.JobRunner {
       job.image,
       job.imageForcePull,
       this.serviceAccount,
-      job.resourceRequests
+      job.resourceRequests,
+      job.keepCommand
     );
 
     // Experimenting with setting a deadline field after which something
@@ -646,7 +647,8 @@ function newRunnerPod(
   brigadeImage: string,
   imageForcePull: boolean,
   serviceAccount: string,
-  resourceRequests: jobs.JobResourceRequest
+  resourceRequests: jobs.JobResourceRequest,
+  keepCommand: boolean
 ): kubernetes.V1Pod {
   let pod = new kubernetes.V1Pod();
   pod.metadata = new kubernetes.V1ObjectMeta();
@@ -659,7 +661,13 @@ function newRunnerPod(
   let c1 = new kubernetes.V1Container();
   c1.name = "brigaderun";
   c1.image = brigadeImage;
-  c1.command = ["/bin/sh", "/hook/main.sh"];
+
+  if (keepCommand) {
+    c1.args = ["/bin/sh", "/hook/main.sh"];
+  } else {
+    c1.command = ["/bin/sh", "/hook/main.sh"];
+  }
+
   c1.imagePullPolicy = imageForcePull ? "Always" : "IfNotPresent";
   c1.securityContext = new kubernetes.V1SecurityContext();
   if (resourceRequests.cpu && resourceRequests.memory) {

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -180,6 +180,16 @@ describe("k8s", function() {
           assert.notProperty(jr.secret.data, "main.sh");
         });
       });
+      context("when keepCommand is set to true", function () {
+        beforeEach(function() {
+          j.keepCommand = true;
+        });
+        it("puts the tasks as args instead of command", function() {
+          let jr = new k8s.JobRunner(j, e, p);
+          assert.isUndefined(jr.runner.spec.containers[0].command);
+          assert.deepEqual(jr.runner.spec.containers[0].args, ["/bin/sh", "/hook/main.sh"]);
+        })
+      });
       context("when useSource is set to false", function() {
         beforeEach(function() {
           j.tasks = [];


### PR DESCRIPTION
The `JobRunner` currently always sets the `job.tasks` array to the `command` option, which maps to Docker's `ENTRYPOINT`.  This can be a problem for some containers that have entrypoints that take actions before executing the intended command.  (For example, for us, we have an entrypoint script that authenticates the container to Vault and grabs secrets.)

This PR adds a `keepCommand` option that permits the user to specify on a per-job basis that Brigade should instead put the content of `tasks` into `args` (Docker's `CMD`) rather than `command`.  We're using this in production right now and it seems to work.