### PR TITLE
feat(worker): support passing args through jobs

### DIFF
--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -33,7 +33,7 @@ var (
 	runNoProgress bool
 )
 
-var logPattern = regexp.MustCompile("\\[brigade:k8s\\]\\s[a-zA-Z0-9-]+/[a-zA-Z0-9-]+ phase \\w+")
+var logPattern = regexp.MustCompile(`\[brigade:k8s\]\s[a-zA-Z0-9-]+/[a-zA-Z0-9-]+ phase \w+`)
 
 const (
 	defaultRef  = "master"

--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -93,8 +93,8 @@ func TestController(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 14 {
-		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 15 {
+		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -114,8 +114,8 @@ func TestController(t *testing.T) {
 		t.Fatalf("Expected 1 init container, got %d", l)
 	}
 	ic := pod.Spec.InitContainers[0]
-	if envlen := len(ic.Env); envlen != 14 {
-		t.Errorf("expected 14 env vars, got %d", envlen)
+	if envlen := len(ic.Env); envlen != 15 {
+		t.Errorf("expected 15 env vars, got %d", envlen)
 	}
 
 	if ic.Image != sidecarImage {
@@ -210,8 +210,8 @@ func TestController_WithScript(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 14 {
-		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 15 {
+		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -284,8 +284,8 @@ func TestController_NoSidecar(t *testing.T) {
 	}
 
 	c := pod.Spec.Containers[0]
-	if envlen := len(c.Env); envlen != 14 {
-		t.Errorf("expected 14 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != 15 {
+		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -513,8 +513,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 			if c.Name != "brigade-runner" {
 				t.Error("Container.Name is not correct")
 			}
-			if envlen := len(c.Env); envlen != 14 {
-				t.Errorf("expected 14 items in Container.Env, got %d", envlen)
+			if envlen := len(c.Env); envlen != 15 {
+				t.Errorf("expected 15 items in Container.Env, got %d", envlen)
 			}
 			if c.Image != test.expWorkerImage {
 				t.Errorf("Container.Image is not correct, got %s; want %s", c.Image, test.expWorkerImage)
@@ -530,8 +530,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 				t.Fatalf("Expected 1 init container, got %d", l)
 			}
 			ic := pod.Spec.InitContainers[0]
-			if envlen := len(ic.Env); envlen != 14 {
-				t.Errorf("expected 14 env vars, got %d", envlen)
+			if envlen := len(ic.Env); envlen != 15 {
+				t.Errorf("expected 15 env vars, got %d", envlen)
 			}
 
 			if ic.Image != sidecarImage {

--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -158,6 +158,8 @@ export abstract class Job {
   public shell: string = defaultShell;
   /** tasks is a list of tasks run inside of the shell*/
   public tasks: string[];
+  /** args is a list of arguments that will be supplied to the container.*/
+  public args: string[];
   /** env is the environment variables for the job*/
   public env: { [key: string]: string | V1EnvVarSource };
   /** image is the container image to be run*/
@@ -245,6 +247,7 @@ export abstract class Job {
     this.image = image;
     this.imageForcePull = imageForcePull;
     this.tasks = tasks || [];
+    this.args = [];
     this.env = {};
     this.cache = new JobCache();
     this.storage = new JobStorage();

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -332,6 +332,10 @@ export class JobRunner implements jobs.JobRunner {
       }
     }
 
+    if (job.args.length > 0) {
+      this.runner.spec.containers[0].args = job.args;
+    }
+
     let newCmd = generateScript(job);
     if (!newCmd) {
       this.runner.spec.containers[0].command = null;

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -170,6 +170,26 @@ describe("k8s", function() {
           assert.equal(jr.runner.spec.serviceAccountName, "custom-worker");
         });
       });
+      context("when args are supplied", function() {
+        beforeEach(function() {
+          j.tasks = [];
+          j.args = ["--aye", "-j", "kay"]
+        });
+        it("adds container args", function() {
+          let jr = new k8s.JobRunner(j, e, p);
+          assert.equal(jr.runner.spec.containers[0].args.length, 3);
+          assert.notProperty(jr.secret.data, "main.sh");
+        });
+      });
+      context("when no args are supplied", function() {
+        beforeEach(function() {
+          j.args = [];
+        });
+        it("has no container args", function() {
+          let jr = new k8s.JobRunner(j, e, p);
+          assert.notProperty(jr.runner.spec.containers[0], "args");
+        });
+      });
       context("when no tasks are supplied", function() {
         beforeEach(function() {
           j.tasks = [];

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -173,7 +173,7 @@ describe("k8s", function() {
       context("when args are supplied", function() {
         beforeEach(function() {
           j.tasks = [];
-          j.args = ["--aye", "-j", "kay"]
+          j.args = ["--aye", "-j", "kay"];
         });
         it("adds container args", function() {
           let jr = new k8s.JobRunner(j, e, p);

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -172,8 +172,12 @@ Properties of `Job`
 
 - `name: string`: The job name
 - `shell: string`: The shell in which to execute the tasks (`/bin/sh`)
-- `tasks: string[]`: Tasks to be run in the job, in order.
+- `tasks: string[]`: Tasks to be run in the job, in order. Tasks are concatenated
+  together and packaged as a Borne (`/bin/sh`) shell script with `set -eo pipefail`.
+- `args: string[]`: Arguments to pass to the container's entrypoint. It is recommended,
+  though not required, that implementors not use both `args` and `tasks`.
 - `imageForcePull: boolean`: Defines the container image pull policy: `Always` if `true` or `IfNotPresent` if `false` (defaults to `false`).
+- `tasks: string[]`: Tasks to be run in the job, in order.
 - `env: {[key: string]:string}`: Name/value pairs of environment variables.
 - `image: string`: The container image to run
 - `imagePullSecrets: string`: The names of the pull secrets (for pulling images from a secure remote repository)


### PR DESCRIPTION
Adds `Job.args: []string` so that users can set `args` on a container directly, bypassing the `tasks` scripting behavior.

Also fixes a few test errors. 

Closes #411 

