### PR TITLE
Use .stringData to avoid base64 encoding & decoding.

### DIFF
--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -11,44 +11,45 @@ metadata:
   annotations:
     projectName: {{ .Values.project | quote }}
 type: "brigade.sh/project"
-data:
-  repository: {{ .Values.repository | b64enc }}
-  sharedSecret: {{ .Values.sharedSecret | b64enc }}
-  cloneURL: {{ .Values.cloneURL | b64enc }}
-  initGitSubmodules: {{ default "false" .Values.initGitSubmodules | b64enc }}
+stringData:
+  repository: {{ .Values.repository }}
+  sharedSecret: {{ .Values.sharedSecret }}
+  cloneURL: {{ .Values.cloneURL }}
+  initGitSubmodules: {{ default "false" .Values.initGitSubmodules }}
   {{ if .Values.defaultScript }}
-  defaultScript: {{.Values.defaultScript | b64enc }}
+  defaultScript: |
+{{.Values.defaultScript | indent 4}}
   {{- end }}
   {{ if eq "NONE" .Values.vcsSidecar -}}
   {{- else if empty .Values.vcsSidecar -}}
-  vcsSidecar: {{ printf "deis/git-sidecar:%s" .Chart.Version | b64enc }}
+  vcsSidecar: {{ printf "deis/git-sidecar:%s" .Chart.Version }}
   {{- else }}
-  vcsSidecar: {{ .Values.vcsSidecar | b64enc }}
+  vcsSidecar: {{ .Values.vcsSidecar }}
   {{- end }}
   {{ if .Values.buildStorageSize }}
-  buildStorageSize: {{ .Values.buildStorageSize | b64enc }}
+  buildStorageSize: {{ .Values.buildStorageSize }}
   {{- end }}
   {{ if .Values.secrets }}
-  secrets: {{ .Values.secrets | toJson | b64enc }}
+  secrets: '{{ .Values.secrets | toJson }}'
   {{- end }}
   {{ range $k, $v := .Values.github}}
-  github.{{ $k }}: {{ b64enc $v }}
+  github.{{ $k }}: {{ $v }}
   {{- end }}
   {{ range $k, $v := .Values.kubernetes }}
-  kubernetes.{{ $k }}: {{ b64enc $v }}
+  kubernetes.{{ $k }}: {{ $v }}
   {{- end }}
   {{ if .Values.sshKey }}
-  sshKey: {{.Values.sshKey | replace "\n" "$" | b64enc }}
+  sshKey: {{.Values.sshKey | replace "\n" "$" }}
   {{- end }}
-  allowPrivilegedJobs: {{ default "true" .Values.allowPrivilegedJobs | b64enc }}
+  allowPrivilegedJobs: {{ default "true" .Values.allowPrivilegedJobs }}
   {{ if .Values.allowHostMounts -}}
-  allowHostMounts: {{b64enc .Values.allowHostMounts }}
+  allowHostMounts: {{ .Values.allowHostMounts }}
   {{ else }}
-  allowHostMounts: {{ b64enc "false" }}
+  allowHostMounts: {{ "false" }}
   {{- end }}
   {{ range $k, $v := .Values.worker -}}
-  worker.{{ $k }}: {{ b64enc $v }}
+  worker.{{ $k }}: {{ $v }}
   {{ end -}}
   {{if .Values.workerCommand -}}
-  workerCommand: {{.Values.workerCommand | b64enc }}
+  workerCommand: {{.Values.workerCommand }}
   {{- end }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -50,7 +50,7 @@ github:
 #
 #   events.push = function(e, p) {
 #     j = new Job("example")
-#     j.env= {"MY_ENV_VAR", p.secrets.myVar}
+#     j.env= {"MY_ENV_VAR": p.secrets.myVar}
 #   }
 #
 # And here, add this:


### PR DESCRIPTION
Related to https://github.com/Azure/brigade/issues/419.

Using `.stringData` makes working with Secret data simpler because clients don't need to base64 encode values back-and-forth when editing.

As a Brigade user using Helm, this improves readability of the templated Helm chart.

As a Brigade user not using Helm, I can copy templates/secret.yaml to create a new project and easily edit my project configuration in plain text.

Tested by uncommenting most variables in the default values.yaml and running:

```
helm template charts/brigade-project -n myProject | kubectl apply --dry-run --validate -f -
```