### PR TITLE
When base64 was removed, no escaping was done on any values.

### DIFF
--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -12,10 +12,10 @@ metadata:
     projectName: {{ .Values.project | quote }}
 type: "brigade.sh/project"
 stringData:
-  repository: {{ .Values.repository }}
-  sharedSecret: {{ .Values.sharedSecret }}
-  cloneURL: {{ .Values.cloneURL }}
-  initGitSubmodules: {{ default "false" .Values.initGitSubmodules }}
+  repository: {{ .Values.repository | quote }}
+  sharedSecret: {{ .Values.sharedSecret | quote }}
+  cloneURL: {{ .Values.cloneURL | quote }}
+  initGitSubmodules: {{ default "false" .Values.initGitSubmodules | quote }}
   {{ if .Values.defaultScript }}
   defaultScript: |
 {{.Values.defaultScript | indent 4}}
@@ -24,32 +24,32 @@ stringData:
   {{- else if empty .Values.vcsSidecar -}}
   vcsSidecar: {{ printf "deis/git-sidecar:%s" .Chart.Version }}
   {{- else }}
-  vcsSidecar: {{ .Values.vcsSidecar }}
+  vcsSidecar: {{ .Values.vcsSidecar | quote }}
   {{- end }}
   {{ if .Values.buildStorageSize }}
-  buildStorageSize: {{ .Values.buildStorageSize }}
+  buildStorageSize: {{ .Values.buildStorageSize | quote }}
   {{- end }}
   {{ if .Values.secrets }}
   secrets: '{{ .Values.secrets | toJson }}'
   {{- end }}
   {{ range $k, $v := .Values.github}}
-  github.{{ $k }}: {{ $v }}
+  github.{{ $k }}: {{ $v | quote }}
   {{- end }}
   {{ range $k, $v := .Values.kubernetes }}
-  kubernetes.{{ $k }}: {{ $v }}
+  kubernetes.{{ $k }}: {{ $v | quote }}
   {{- end }}
   {{ if .Values.sshKey }}
   sshKey: {{.Values.sshKey | replace "\n" "$" }}
   {{- end }}
-  allowPrivilegedJobs: {{ default "true" .Values.allowPrivilegedJobs }}
+  allowPrivilegedJobs: {{ default "true" .Values.allowPrivilegedJobs | quote }}
   {{ if .Values.allowHostMounts -}}
-  allowHostMounts: {{ .Values.allowHostMounts }}
+  allowHostMounts: {{ .Values.allowHostMounts | quote }}
   {{ else }}
-  allowHostMounts: {{ "false" }}
+  allowHostMounts: "false"
   {{- end }}
   {{ range $k, $v := .Values.worker -}}
-  worker.{{ $k }}: {{ $v }}
+  worker.{{ $k }}: {{ $v | quote }}
   {{ end -}}
   {{if .Values.workerCommand -}}
-  workerCommand: {{.Values.workerCommand }}
+  workerCommand: {{.Values.workerCommand | quote }}
   {{- end }}


### PR DESCRIPTION
This causes massive breakage on:
- bools
- numeric strings
- anything with a reserved character in YAML

So we quote all of the values that could be problematic.