### PR TITLE
Improve brig api performance as seen in #433 by introducing caching

### DIFF
--- a/pkg/merge/channels.go
+++ b/pkg/merge/channels.go
@@ -1,0 +1,44 @@
+package merge
+
+// this package offers utility methods to merge things like channels
+
+func Channels(chans ...<-chan struct{}) <-chan struct{} {
+	switch len(chans) {
+	case 0:
+		c := make(chan struct{})
+		close(c)
+		return c
+	case 1:
+		return chans[0]
+	default:
+		m := len(chans) / 2
+		return mergeTwoChannels(
+			Channels(chans[:m]...),
+			Channels(chans[m:]...))
+	}
+}
+
+func mergeTwoChannels(a, b <-chan struct{}) <-chan struct{} {
+	c := make(chan struct{})
+
+	go func() {
+		defer close(c)
+		for a != nil || b != nil {
+			select {
+			case v, ok := <-a:
+				if !ok {
+					a = nil
+					continue
+				}
+				c <- v
+			case v, ok := <-b:
+				if !ok {
+					b = nil
+					continue
+				}
+				c <- v
+			}
+		}
+	}()
+	return c
+}

--- a/pkg/merge/channels.go
+++ b/pkg/merge/channels.go
@@ -2,6 +2,7 @@ package merge
 
 // this package offers utility methods to merge things like channels
 
+// Channels merges multiple channels into one channel
 func Channels(chans ...<-chan struct{}) <-chan struct{} {
 	switch len(chans) {
 	case 0:

--- a/pkg/merge/channels_test.go
+++ b/pkg/merge/channels_test.go
@@ -1,0 +1,64 @@
+package merge
+
+import (
+	"testing"
+)
+
+func TestMergeChannels2(t *testing.T) {
+
+	c1 := make(chan struct{})
+	c2 := make(chan struct{})
+
+	merged := Channels(c1, c2)
+	close(c1)
+	close(c2)
+
+	_, ok := <-merged
+	if ok {
+		t.Fatal("merged chan expected to be closed")
+	}
+}
+
+func TestMergeChannels3(t *testing.T) {
+
+	c1 := make(chan struct{})
+	c2 := make(chan struct{})
+	c3 := make(chan struct{})
+
+	merged := Channels(c1, c2, c3)
+	close(c1)
+	close(c2)
+	close(c3)
+
+	_, ok := <-merged
+	if ok {
+		t.Fatal("merged chan expected to be closed")
+	}
+}
+
+func TestMergeZero(t *testing.T) {
+	merged := Channels()
+	_, ok := <-merged
+	if ok {
+		t.Fatal("merged chan expected to be closed")
+	}
+}
+
+func TestMergeTwo(t *testing.T) {
+	c1 := make(chan struct{})
+	c2 := make(chan struct{})
+	merged := mergeTwoChannels(c1, c2)
+	go func() {
+		for i := 0;i<2;i++  {
+			<-merged
+		}
+	}()
+	c1 <- struct{}{}
+	c2 <- struct{}{}
+	close(c1)
+	close(c2)
+	_, ok := <-merged
+	if ok {
+		t.Fatal("merged chan expected to be closed")
+	}
+}

--- a/pkg/merge/channels_test.go
+++ b/pkg/merge/channels_test.go
@@ -49,7 +49,7 @@ func TestMergeTwo(t *testing.T) {
 	c2 := make(chan struct{})
 	merged := mergeTwoChannels(c1, c2)
 	go func() {
-		for i := 0;i<2;i++  {
+		for i := 0; i < 2; i++ {
 			<-merged
 		}
 	}()

--- a/pkg/storage/kube/apicache/cache.go
+++ b/pkg/storage/kube/apicache/cache.go
@@ -3,73 +3,82 @@ package apicache
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/fields"
 	"time"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/apimachinery/pkg/runtime"
-	"github.com/davecgh/go-spew/spew"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"github.com/Azure/brigade/pkg/merge"
 )
 
 type ApiCache interface {
+	// get cached secrets filtered by label selectors k/v pairs
 	GetSecretsFilteredBy(labelSelectors map[string]string) []v1.Secret
+	// get cached pods filtered by label selectors k/v pairs
 	GetPodsFilteredBy(labelSelectors map[string]string) []v1.Pod
+	// blocks until the api cache is populated
+	// returns true when cache is synced or false when timeout reached
+	BlockUntilApiCacheSynced(waitUntil <-chan time.Time) bool
 }
 
 type apiCache struct {
-	client      kubernetes.Interface
-	secretStore cache.Store
-	podStore    cache.Store
-}
-
-func New(kubernetesClient kubernetes.Interface, namespace string, resyncPeriod time.Duration) ApiCache {
-	return &apiCache{
-		client: kubernetesClient,
-		secretStore: newListStore(kubernetesClient, storeConfig{
-			resource:     "secrets",
-			namespace:    namespace,
-			resyncPeriod: resyncPeriod,
-			expectedType: &v1.Secret{},
-		}),
-		podStore: newListStore(kubernetesClient, storeConfig{
-			resource:     "pods",
-			namespace:    namespace,
-			resyncPeriod: resyncPeriod,
-			expectedType: &v1.Pod{},
-		}),
-	}
+	// the kubernetes client
+	client             kubernetes.Interface
+	// a ready to use cache.Store for secrets
+	secretStore        cache.Store
+	// a ready to use cache.Store for pods
+	podStore           cache.Store
+	// a chan which is going to be closed after the ApiCache has initially synced all cache.Store's
+	hasSyncedInitially <-chan struct{}
 }
 
 type storeConfig struct {
+	// the kubernetes resource to listen to (e.g. 'pods', 'secrets', etc.)
 	resource     string
+	// the kubernetes namespace to filter by
 	namespace    string
+	// how often to re-sync
 	resyncPeriod time.Duration
+	// which type to expect when new synced objects arrive
 	expectedType runtime.Object
+	// implement the method invokind the kubernetes.Interface to return
+	// a List of the expected runtime.Object type
+	listFunc     func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error)
+	// implement the method invoking the kubernetes.Interface to return
+	// a watch.Interface that returns the expected runtime.Object type
+	watchFunc    func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error)
 }
 
-func newListStore(client kubernetes.Interface, config storeConfig) cache.Store {
+func New(client kubernetes.Interface, namespace string, resyncPeriod time.Duration) ApiCache {
 
-	listWatch := cache.NewListWatchFromClient(
-		client.CoreV1().RESTClient(),
-		config.resource,
-		config.namespace,
-		fields.Everything())
+	secretsSynced := make(chan struct{})
+	podsSynced := make(chan struct{})
 
-	store, ctr := cache.NewInformer(
-		listWatch,
-		config.expectedType,
-		config.resyncPeriod,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				spew.Dump("object added",obj)
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				spew.Dump("object updated",oldObj,newObj)
-			},
-			DeleteFunc: func(obj interface{}) {
-				spew.Dump("object deleted",obj)
-			},
-		})
+	merged := merge.Channels(secretsSynced, podsSynced)
 
-	go ctr.Run(nil)
-	return store
+	return &apiCache{
+		hasSyncedInitially: merged,
+		client:             client,
+		secretStore:        secretStoreFactory{}.new(client, namespace, resyncPeriod, secretsSynced),
+		podStore:           podStoreFactory{}.new(client, namespace, resyncPeriod, podsSynced),
+	}
+}
+
+// Blocks until all cache.Store's are synced
+// returns true if all channels are closed
+// returns false if the timeout was reached (in case waitUntil is not nil)
+func (a *apiCache) BlockUntilApiCacheSynced(waitUntil <-chan time.Time) bool {
+	if waitUntil == nil {
+		<-a.hasSyncedInitially
+		return true
+	} else {
+		select {
+		case <-waitUntil:
+			return false
+		case _, ok := <-a.hasSyncedInitially:
+			// ok == false when all merged channels are closed
+			// therefore return !ok to indicate every listener is synced if that's the case
+			return !ok
+		}
+	}
 }

--- a/pkg/storage/kube/apicache/cache.go
+++ b/pkg/storage/kube/apicache/cache.go
@@ -1,55 +1,60 @@
 package apicache
 
 import (
-	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"time"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/Azure/brigade/pkg/merge"
 )
 
-type ApiCache interface {
+// APICache continuously queries the kubernetes api and caches secret and pod information in the current implementation
+// this way dashboards can be build faster
+type APICache interface {
 	// get cached secrets filtered by label selectors k/v pairs
 	GetSecretsFilteredBy(labelSelectors map[string]string) []v1.Secret
 	// get cached pods filtered by label selectors k/v pairs
 	GetPodsFilteredBy(labelSelectors map[string]string) []v1.Pod
 	// blocks until the api cache is populated
 	// returns true when cache is synced or false when timeout reached
-	BlockUntilApiCacheSynced(waitUntil <-chan time.Time) bool
+	BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool
 }
 
 type apiCache struct {
 	// the kubernetes client
-	client             kubernetes.Interface
+	client kubernetes.Interface
 	// a ready to use cache.Store for secrets
-	secretStore        cache.Store
+	secretStore cache.Store
 	// a ready to use cache.Store for pods
-	podStore           cache.Store
-	// a chan which is going to be closed after the ApiCache has initially synced all cache.Store's
+	podStore cache.Store
+	// a chan which is going to be closed after the APICache has initially synced all cache.Store's
 	hasSyncedInitially <-chan struct{}
 }
 
 type storeConfig struct {
 	// the kubernetes resource to listen to (e.g. 'pods', 'secrets', etc.)
-	resource     string
+	resource string
 	// the kubernetes namespace to filter by
-	namespace    string
+	namespace string
 	// how often to re-sync
 	resyncPeriod time.Duration
 	// which type to expect when new synced objects arrive
 	expectedType runtime.Object
 	// implement the method invokind the kubernetes.Interface to return
 	// a List of the expected runtime.Object type
-	listFunc     func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error)
+	listFunc func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error)
 	// implement the method invoking the kubernetes.Interface to return
 	// a watch.Interface that returns the expected runtime.Object type
-	watchFunc    func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error)
+	watchFunc func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error)
 }
 
-func New(client kubernetes.Interface, namespace string, resyncPeriod time.Duration) ApiCache {
+// New returns a new APICache
+func New(client kubernetes.Interface, namespace string, resyncPeriod time.Duration) APICache {
 
 	secretsSynced := make(chan struct{})
 	podsSynced := make(chan struct{})
@@ -64,21 +69,21 @@ func New(client kubernetes.Interface, namespace string, resyncPeriod time.Durati
 	}
 }
 
-// Blocks until all cache.Store's are synced
+// BlockUntilAPICacheSynced blocks until all cache.Store's are synced
 // returns true if all channels are closed
 // returns false if the timeout was reached (in case waitUntil is not nil)
-func (a *apiCache) BlockUntilApiCacheSynced(waitUntil <-chan time.Time) bool {
+func (a *apiCache) BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool {
 	if waitUntil == nil {
 		<-a.hasSyncedInitially
 		return true
-	} else {
-		select {
-		case <-waitUntil:
-			return false
-		case _, ok := <-a.hasSyncedInitially:
-			// ok == false when all merged channels are closed
-			// therefore return !ok to indicate every listener is synced if that's the case
-			return !ok
-		}
+	}
+
+	select {
+	case <-waitUntil:
+		return false
+	case _, ok := <-a.hasSyncedInitially:
+		// ok == false when all merged channels are closed
+		// therefore return !ok to indicate every listener is synced if that's the case
+		return !ok
 	}
 }

--- a/pkg/storage/kube/apicache/cache.go
+++ b/pkg/storage/kube/apicache/cache.go
@@ -1,0 +1,75 @@
+package apicache
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/fields"
+	"time"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/davecgh/go-spew/spew"
+)
+
+type ApiCache interface {
+	GetSecretsFilteredBy(labelSelectors map[string]string) []v1.Secret
+	GetPodsFilteredBy(labelSelectors map[string]string) []v1.Pod
+}
+
+type apiCache struct {
+	client      kubernetes.Interface
+	secretStore cache.Store
+	podStore    cache.Store
+}
+
+func New(kubernetesClient kubernetes.Interface, namespace string, resyncPeriod time.Duration) ApiCache {
+	return &apiCache{
+		client: kubernetesClient,
+		secretStore: newListStore(kubernetesClient, storeConfig{
+			resource:     "secrets",
+			namespace:    namespace,
+			resyncPeriod: resyncPeriod,
+			expectedType: &v1.Secret{},
+		}),
+		podStore: newListStore(kubernetesClient, storeConfig{
+			resource:     "pods",
+			namespace:    namespace,
+			resyncPeriod: resyncPeriod,
+			expectedType: &v1.Pod{},
+		}),
+	}
+}
+
+type storeConfig struct {
+	resource     string
+	namespace    string
+	resyncPeriod time.Duration
+	expectedType runtime.Object
+}
+
+func newListStore(client kubernetes.Interface, config storeConfig) cache.Store {
+
+	listWatch := cache.NewListWatchFromClient(
+		client.CoreV1().RESTClient(),
+		config.resource,
+		config.namespace,
+		fields.Everything())
+
+	store, ctr := cache.NewInformer(
+		listWatch,
+		config.expectedType,
+		config.resyncPeriod,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				spew.Dump("object added",obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				spew.Dump("object updated",oldObj,newObj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				spew.Dump("object deleted",obj)
+			},
+		})
+
+	go ctr.Run(nil)
+	return store
+}

--- a/pkg/storage/kube/apicache/cache_test.go
+++ b/pkg/storage/kube/apicache/cache_test.go
@@ -2,25 +2,26 @@ package apicache
 
 import (
 	"testing"
-	"k8s.io/client-go/kubernetes/fake"
 	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestApiCache(t *testing.T) {
 
 	client := fake.NewSimpleClientset()
 
-	cache := New(client,"default",time.Millisecond * time.Duration(500))
+	cache := New(client, "default", time.Millisecond*time.Duration(500))
 	if cache == nil {
 		t.Fatal("expected cache not to ne nil")
 	}
 
-	syncedWithinOneSecond := cache.BlockUntilApiCacheSynced(time.After(time.Second))
+	syncedWithinOneSecond := cache.BlockUntilAPICacheSynced(time.After(time.Second))
 	if !syncedWithinOneSecond {
 		t.Fatal("expected to sync within one second")
 	}
 
-	syncedWithoutTimeout := cache.BlockUntilApiCacheSynced(nil)
+	syncedWithoutTimeout := cache.BlockUntilAPICacheSynced(nil)
 	if !syncedWithoutTimeout {
 		t.Fatal("expected to sync without timeout")
 	}
@@ -30,12 +31,12 @@ func TestApiCacheBlockUntilApiCacheSynced(t *testing.T) {
 
 	client := fake.NewSimpleClientset()
 
-	cache := New(client,"default",time.Millisecond * time.Duration(500))
+	cache := New(client, "default", time.Millisecond*time.Duration(500))
 	if cache == nil {
 		t.Fatal("expected cache not to ne nil")
 	}
 
-	syncedAfterZeroTime := cache.BlockUntilApiCacheSynced(time.After(0))
+	syncedAfterZeroTime := cache.BlockUntilAPICacheSynced(time.After(0))
 	if syncedAfterZeroTime {
 		t.Fatal("expected to sync within one second")
 	}

--- a/pkg/storage/kube/apicache/cache_test.go
+++ b/pkg/storage/kube/apicache/cache_test.go
@@ -1,0 +1,37 @@
+package apicache
+
+import (
+	"testing"
+	"k8s.io/client-go/kubernetes/fake"
+	"time"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApiCache(t *testing.T){
+
+	labels := map[string]string{
+		"foo": "bar",
+	}
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: labels,
+		},
+		Spec: v1.PodSpec{
+			Hostname: "foo",
+		},
+		Status: v1.PodStatus{
+
+		},
+	}
+
+	client := fake.NewSimpleClientset(&pod)
+	// unexpectedly the api cache stays empty
+	apiCache := New(client,"default",time.Second * time.Duration(30))
+
+	pods := apiCache.GetPodsFilteredBy(labels)
+	if len(pods) != 1 {
+		t.Fatalf("expected 1 but found %d",len(pods))
+	}
+}

--- a/pkg/storage/kube/apicache/liststore.go
+++ b/pkg/storage/kube/apicache/liststore.go
@@ -1,0 +1,76 @@
+package apicache
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+type cacheStoreFactory interface {
+	new(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, synced chan struct{}) cache.Store
+}
+
+// convenience method to create listStores
+func newListStore(client kubernetes.Interface, config storeConfig, hasSynced chan struct{}) cache.Store {
+
+	listWatch := cache.ListWatch{
+		ListFunc: func(options metaV1.ListOptions) (runtime.Object, error) {
+			return config.listFunc(client, config.namespace, options)
+		},
+		WatchFunc: func(options metaV1.ListOptions) (watch.Interface, error) {
+			return config.watchFunc(client, config.namespace, options)
+		},
+	}
+
+	store, ctr := cache.NewInformer(
+		&listWatch,
+		config.expectedType,
+		config.resyncPeriod,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) {},
+			UpdateFunc: func(oldObj, newObj interface{}) {},
+			DeleteFunc: func(obj interface{}) {},
+		})
+
+	// run the controller in a new goroutine, else this operation would block
+	// we currently don't supply a close chan as there is no need to
+	// this might change
+	go ctr.Run(nil)
+
+	// loop until the store is in sync, then close the chan to signal
+	go func(ctr cache.Controller) {
+		for {
+			if hasSynced == nil {
+				break
+			}
+
+			if ctr.HasSynced() {
+				// if this panics you might unintentionally closed this channel from outside
+				// please fix your code as this behavior is not not expected
+				close(hasSynced)
+				hasSynced = nil
+				break
+			}
+		}
+	}(ctr)
+
+	return store
+}
+
+// returns true under these conditions:
+// 1. all keys from the expected map exist on the actual map
+// 2. all values from the expected map match those from the actual map
+// else false
+func stringMapsMatch(actual, expected map[string]string) bool {
+	for key, expected := range expected {
+		actual, exists := actual[key]
+		if !exists || actual != expected {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/storage/kube/apicache/liststore.go
+++ b/pkg/storage/kube/apicache/liststore.go
@@ -1,12 +1,13 @@
 package apicache
 
 import (
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/apimachinery/pkg/runtime"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 type cacheStoreFactory interface {

--- a/pkg/storage/kube/apicache/liststore.go
+++ b/pkg/storage/kube/apicache/liststore.go
@@ -1,18 +1,12 @@
 package apicache
 
 import (
-	"time"
-
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
-
-type cacheStoreFactory interface {
-	new(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, synced chan struct{}) cache.Store
-}
 
 // convenience method to create listStores
 func newListStore(client kubernetes.Interface, config storeConfig, hasSynced chan struct{}) cache.Store {

--- a/pkg/storage/kube/apicache/liststore_test.go
+++ b/pkg/storage/kube/apicache/liststore_test.go
@@ -1,0 +1,125 @@
+package apicache
+
+import (
+	"testing"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+func TestNewListStoreWithoutHasSyncedChan(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	store := newListStore(client, storeConfig{
+		resource:     "secrets",
+		namespace:    "default",
+		resyncPeriod: time.Millisecond * time.Duration(100),
+		expectedType: &v1.Secret{},
+		listFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Secrets(namespace).List(options)
+		},
+		watchFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Secrets(namespace).Watch(options)
+		},
+	}, nil)
+
+	if store == nil {
+		t.Fatal("expected store to not be nil when hasSynced is nil")
+	}
+}
+
+func TestNewListStoreInvokeWatchFunctions(t *testing.T) {
+
+	client := fake.NewSimpleClientset()
+
+	hasSynced := make(chan struct{})
+	store := newListStore(client, storeConfig{
+		resource:     "secrets",
+		namespace:    "default",
+		resyncPeriod: 1,
+		expectedType: &v1.Secret{},
+		listFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Secrets(namespace).List(options)
+		},
+		watchFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Secrets(namespace).Watch(options)
+		},
+	}, hasSynced)
+
+	if store == nil {
+		t.Fatal("expected store to not be nil")
+	}
+
+	// cover the watch functions
+	secret := v1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "fooBar",
+		},
+		StringData: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	created, err := client.CoreV1().Secrets("default").Create(&secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond * time.Duration(10))
+	if len(store.List()) != 1 {
+		t.Fatal("expected store to contain one object")
+	}
+
+	_, err = client.CoreV1().Secrets("default").Update(created)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+	err = client.CoreV1().Secrets("default").Delete(created.Name, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+	// seems like the fake impl doesn't delete objects
+	// this can be seen when looking at a cover html
+
+	/*if len(store.List()) != 0 {
+		spew.Dump(afterCreation,store.List())
+		t.Fatal("expected store to be empty after deletion")
+	}*/
+}
+
+func TestStringMapsMatch(t *testing.T){
+
+	expected := map[string]string{
+		"foo" : "bar",
+		"bar" : "baz",
+	}
+
+	keyMissing := map[string]string {
+		"foo" : "bar",
+	}
+
+	invalidValue := map[string]string {
+		"foo" : "bar",
+		"bar" : "bar",
+	}
+
+	if !stringMapsMatch(expected,expected) {
+		t.Fatal("expected maps to match")
+	}
+
+	if stringMapsMatch(keyMissing,expected){
+		t.Fatal("expected not to match because key is missing")
+	}
+
+	if stringMapsMatch(invalidValue,expected){
+		t.Fatal("expected not to match because one value is invalid")
+	}
+}

--- a/pkg/storage/kube/apicache/liststore_test.go
+++ b/pkg/storage/kube/apicache/liststore_test.go
@@ -2,13 +2,14 @@ package apicache
 
 import (
 	"testing"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apimachinery/pkg/runtime"
+	"time"
+
 	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewListStoreWithoutHasSyncedChan(t *testing.T) {
@@ -84,42 +85,33 @@ func TestNewListStoreInvokeWatchFunctions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	time.Sleep(time.Millisecond)
-	// seems like the fake impl doesn't delete objects
-	// this can be seen when looking at a cover html
-
-	/*if len(store.List()) != 0 {
-		spew.Dump(afterCreation,store.List())
-		t.Fatal("expected store to be empty after deletion")
-	}*/
 }
 
-func TestStringMapsMatch(t *testing.T){
+func TestStringMapsMatch(t *testing.T) {
 
 	expected := map[string]string{
-		"foo" : "bar",
-		"bar" : "baz",
+		"foo": "bar",
+		"bar": "baz",
 	}
 
-	keyMissing := map[string]string {
-		"foo" : "bar",
+	keyMissing := map[string]string{
+		"foo": "bar",
 	}
 
-	invalidValue := map[string]string {
-		"foo" : "bar",
-		"bar" : "bar",
+	invalidValue := map[string]string{
+		"foo": "bar",
+		"bar": "bar",
 	}
 
-	if !stringMapsMatch(expected,expected) {
+	if !stringMapsMatch(expected, expected) {
 		t.Fatal("expected maps to match")
 	}
 
-	if stringMapsMatch(keyMissing,expected){
+	if stringMapsMatch(keyMissing, expected) {
 		t.Fatal("expected not to match because key is missing")
 	}
 
-	if stringMapsMatch(invalidValue,expected){
+	if stringMapsMatch(invalidValue, expected) {
 		t.Fatal("expected not to match because one value is invalid")
 	}
 }

--- a/pkg/storage/kube/apicache/pods.go
+++ b/pkg/storage/kube/apicache/pods.go
@@ -2,16 +2,36 @@ package apicache
 
 import (
 	"k8s.io/api/core/v1"
-	"github.com/davecgh/go-spew/spew"
+	"k8s.io/client-go/kubernetes"
+	"time"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (a *apiCache) GetPodsFilteredBy(labelSelectors map[string]string) []v1.Pod {
+type podStoreFactory struct{}
+
+// return a new cached store for secrets
+func (podStoreFactory) new(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, synced chan struct{}) cache.Store {
+	return newListStore(client, storeConfig{
+		resource:     "pods",
+		namespace:    namespace,
+		resyncPeriod: resyncPeriod,
+		expectedType: &v1.Pod{},
+		listFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Pods(namespace).List(options)
+		},
+		watchFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Pods(namespace).Watch(options)
+		},
+	}, synced)
+}
+
+func (a *apiCache) GetPodsFilteredBy(selectors map[string]string) []v1.Pod {
 
 	var filteredSecrets []v1.Pod
 
-	spew.Dump(a.podStore.List())
-
-OuterLoop:
 	for _, raw := range a.podStore.List() {
 
 		secret, ok := raw.(*v1.Pod)

--- a/pkg/storage/kube/apicache/pods.go
+++ b/pkg/storage/kube/apicache/pods.go
@@ -1,0 +1,34 @@
+package apicache
+
+import (
+	"k8s.io/api/core/v1"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func (a *apiCache) GetPodsFilteredBy(labelSelectors map[string]string) []v1.Pod {
+
+	var filteredSecrets []v1.Pod
+
+	spew.Dump(a.podStore.List())
+
+OuterLoop:
+	for _, raw := range a.podStore.List() {
+
+		secret, ok := raw.(*v1.Pod)
+		if !ok {
+			continue
+		}
+
+		// if the key doesn't exist on the secret or the expected value differs from the actual value, skip it
+		for key, expected := range labelSelectors {
+			actual, exists := secret.Labels[key]
+			if !exists || actual != expected {
+				continue OuterLoop
+			}
+		}
+
+		filteredSecrets = append(filteredSecrets, *secret)
+	}
+
+	return filteredSecrets
+}

--- a/pkg/storage/kube/apicache/pods.go
+++ b/pkg/storage/kube/apicache/pods.go
@@ -39,12 +39,9 @@ func (a *apiCache) GetPodsFilteredBy(selectors map[string]string) []v1.Pod {
 			continue
 		}
 
-		// if the key doesn't exist on the secret or the expected value differs from the actual value, skip it
-		for key, expected := range labelSelectors {
-			actual, exists := secret.Labels[key]
-			if !exists || actual != expected {
-				continue OuterLoop
-			}
+		// skip if the maps don't match
+		if !stringMapsMatch(secret.Labels, selectors) {
+			continue
 		}
 
 		filteredSecrets = append(filteredSecrets, *secret)

--- a/pkg/storage/kube/apicache/pods.go
+++ b/pkg/storage/kube/apicache/pods.go
@@ -1,13 +1,14 @@
 package apicache
 
 import (
-	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"time"
-	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 type podStoreFactory struct{}
@@ -28,6 +29,13 @@ func (podStoreFactory) new(client kubernetes.Interface, namespace string, resync
 	}, synced)
 }
 
+// GetPodsFilteredBy returns all pods filtered by a label selector
+// e.g. for 'heritage=brigade,component=build,project=%s'
+// map[string]string{
+//	"heritage":  "brigade",
+//	"component": "build",
+//	"project":   proj.ID,
+// }
 func (a *apiCache) GetPodsFilteredBy(selectors map[string]string) []v1.Pod {
 
 	var filteredSecrets []v1.Pod

--- a/pkg/storage/kube/apicache/pods_test.go
+++ b/pkg/storage/kube/apicache/pods_test.go
@@ -1,0 +1,70 @@
+package apicache
+
+import (
+	"testing"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+func TestPodStore(t *testing.T) {
+
+	client := fake.NewSimpleClientset()
+
+	factory := podStoreFactory{}
+	store := factory.new(client, "default", 1, nil)
+
+	validLabels := map[string]string{
+		"foo" : "bar",
+	}
+
+	invalidLabels := map[string]string{
+		"bar" : "baz",
+	}
+
+	pod1 := v1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Labels: validLabels,
+			Name: "pod1",
+		},
+	}
+
+	pod2 := v1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Labels: invalidLabels,
+			Name: "pod2",
+		},
+	}
+
+	secret1 := v1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "secret1",
+		},
+	}
+
+	_,err := client.CoreV1().Pods("default").Create(&pod1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_,err = client.CoreV1().Pods("default").Create(&pod2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	// inject a non pod object into the cache (which should get discarded)
+	store.Add(&secret1)
+
+	cache := apiCache{
+		client: client,
+		podStore:store,
+	}
+
+	filteredPods := cache.GetPodsFilteredBy(validLabels)
+	if len(filteredPods) != 1 {
+		t.Fatal("expected len(filtered pods) to be 1")
+	}
+}

--- a/pkg/storage/kube/apicache/pods_test.go
+++ b/pkg/storage/kube/apicache/pods_test.go
@@ -2,10 +2,11 @@ package apicache
 
 import (
 	"testing"
-	"k8s.io/client-go/kubernetes/fake"
+	"time"
+
 	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestPodStore(t *testing.T) {
@@ -16,24 +17,24 @@ func TestPodStore(t *testing.T) {
 	store := factory.new(client, "default", 1, nil)
 
 	validLabels := map[string]string{
-		"foo" : "bar",
+		"foo": "bar",
 	}
 
 	invalidLabels := map[string]string{
-		"bar" : "baz",
+		"bar": "baz",
 	}
 
 	pod1 := v1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
 			Labels: validLabels,
-			Name: "pod1",
+			Name:   "pod1",
 		},
 	}
 
 	pod2 := v1.Pod{
 		ObjectMeta: metaV1.ObjectMeta{
 			Labels: invalidLabels,
-			Name: "pod2",
+			Name:   "pod2",
 		},
 	}
 
@@ -43,12 +44,12 @@ func TestPodStore(t *testing.T) {
 		},
 	}
 
-	_,err := client.CoreV1().Pods("default").Create(&pod1)
+	_, err := client.CoreV1().Pods("default").Create(&pod1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_,err = client.CoreV1().Pods("default").Create(&pod2)
+	_, err = client.CoreV1().Pods("default").Create(&pod2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,8 +60,8 @@ func TestPodStore(t *testing.T) {
 	store.Add(&secret1)
 
 	cache := apiCache{
-		client: client,
-		podStore:store,
+		client:   client,
+		podStore: store,
 	}
 
 	filteredPods := cache.GetPodsFilteredBy(validLabels)

--- a/pkg/storage/kube/apicache/secrets.go
+++ b/pkg/storage/kube/apicache/secrets.go
@@ -1,16 +1,17 @@
 package apicache
 
 import (
+	"time"
+
 	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"time"
 )
 
-type secretStoreFactory struct {}
+type secretStoreFactory struct{}
 
 // return a new cached store for secrets
 func (secretStoreFactory) new(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, synced chan struct{}) cache.Store {
@@ -28,7 +29,7 @@ func (secretStoreFactory) new(client kubernetes.Interface, namespace string, res
 	}, synced)
 }
 
-// returns all secrets filtered by a label selector
+// GetSecretsFilteredBy returns all secrets filtered by a label selector
 // e.g. for 'heritage=brigade,component=build,project=%s'
 // map[string]string{
 //	"heritage":  "brigade",
@@ -47,7 +48,7 @@ func (a *apiCache) GetSecretsFilteredBy(selectors map[string]string) []v1.Secret
 		}
 
 		// skip if the string maps don't match
-		if !stringMapsMatch(secret.Labels,selectors) {
+		if !stringMapsMatch(secret.Labels, selectors) {
 			continue
 		}
 

--- a/pkg/storage/kube/apicache/secrets.go
+++ b/pkg/storage/kube/apicache/secrets.go
@@ -2,7 +2,31 @@ package apicache
 
 import (
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"time"
 )
+
+type secretStoreFactory struct {}
+
+// return a new cached store for secrets
+func (secretStoreFactory) new(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, synced chan struct{}) cache.Store {
+	return newListStore(client, storeConfig{
+		resource:     "secrets",
+		namespace:    namespace,
+		resyncPeriod: resyncPeriod,
+		expectedType: &v1.Secret{},
+		listFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Secrets(namespace).List(options)
+		},
+		watchFunc: func(client kubernetes.Interface, namespace string, options metaV1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Secrets(namespace).Watch(options)
+		},
+	}, synced)
+}
 
 // returns all secrets filtered by a label selector
 // e.g. for 'heritage=brigade,component=build,project=%s'

--- a/pkg/storage/kube/apicache/secrets.go
+++ b/pkg/storage/kube/apicache/secrets.go
@@ -35,11 +35,10 @@ func (secretStoreFactory) new(client kubernetes.Interface, namespace string, res
 //	"component": "build",
 //	"project":   proj.ID,
 // }
-func (a *apiCache) GetSecretsFilteredBy(labelSelectors map[string]string) []v1.Secret {
+func (a *apiCache) GetSecretsFilteredBy(selectors map[string]string) []v1.Secret {
 
 	var filteredSecrets []v1.Secret
 
-	OuterLoop:
 	for _, raw := range a.secretStore.List() {
 
 		secret, ok := raw.(*v1.Secret)
@@ -47,12 +46,9 @@ func (a *apiCache) GetSecretsFilteredBy(labelSelectors map[string]string) []v1.S
 			continue
 		}
 
-		// if the key doesn't exist on the secret or the expected value differs from the actual value, skip it
-		for key, expected := range labelSelectors {
-			actual, exists := secret.Labels[key]
-			if !exists || actual != expected {
-				continue OuterLoop
-			}
+		// skip if the string maps don't match
+		if !stringMapsMatch(secret.Labels,selectors) {
+			continue
 		}
 
 		filteredSecrets = append(filteredSecrets, *secret)

--- a/pkg/storage/kube/apicache/secrets.go
+++ b/pkg/storage/kube/apicache/secrets.go
@@ -1,0 +1,38 @@
+package apicache
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+// returns all secrets filtered by a label selector
+// e.g. for 'heritage=brigade,component=build,project=%s'
+// map[string]string{
+//	"heritage":  "brigade",
+//	"component": "build",
+//	"project":   proj.ID,
+// }
+func (a *apiCache) GetSecretsFilteredBy(labelSelectors map[string]string) []v1.Secret {
+
+	var filteredSecrets []v1.Secret
+
+	OuterLoop:
+	for _, raw := range a.secretStore.List() {
+
+		secret, ok := raw.(*v1.Secret)
+		if !ok {
+			continue
+		}
+
+		// if the key doesn't exist on the secret or the expected value differs from the actual value, skip it
+		for key, expected := range labelSelectors {
+			actual, exists := secret.Labels[key]
+			if !exists || actual != expected {
+				continue OuterLoop
+			}
+		}
+
+		filteredSecrets = append(filteredSecrets, *secret)
+	}
+
+	return filteredSecrets
+}

--- a/pkg/storage/kube/apicache/secrets_test.go
+++ b/pkg/storage/kube/apicache/secrets_test.go
@@ -1,0 +1,70 @@
+package apicache
+
+import (
+	"testing"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+func TestSecretStore(t *testing.T) {
+
+	client := fake.NewSimpleClientset()
+
+	factory := secretStoreFactory{}
+	store := factory.new(client, "default", 1, nil)
+
+	validLabels := map[string]string{
+		"foo" : "bar",
+	}
+
+	invalidLabels := map[string]string{
+		"bar" : "baz",
+	}
+
+	pod1 := v1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "pod1",
+		},
+	}
+
+	secret1 := v1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{
+			Labels:validLabels,
+			Name: "secret1",
+		},
+	}
+
+	secret2 := v1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{
+			Labels:invalidLabels,
+			Name: "secret2",
+		},
+	}
+
+	_,err := client.CoreV1().Secrets("default").Create(&secret1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_,err = client.CoreV1().Secrets("default").Create(&secret2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	// inject a non pod object into the cache (which should get discarded)
+	store.Add(&pod1)
+
+	cache := apiCache{
+		client: client,
+		secretStore:store,
+	}
+
+	filteredPods := cache.GetSecretsFilteredBy(validLabels)
+	if len(filteredPods) != 1 {
+		t.Fatal("expected len(filtered pods) to be 1")
+	}
+}

--- a/pkg/storage/kube/apicache/secrets_test.go
+++ b/pkg/storage/kube/apicache/secrets_test.go
@@ -2,10 +2,11 @@ package apicache
 
 import (
 	"testing"
-	"k8s.io/client-go/kubernetes/fake"
+	"time"
+
 	"k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestSecretStore(t *testing.T) {
@@ -16,11 +17,11 @@ func TestSecretStore(t *testing.T) {
 	store := factory.new(client, "default", 1, nil)
 
 	validLabels := map[string]string{
-		"foo" : "bar",
+		"foo": "bar",
 	}
 
 	invalidLabels := map[string]string{
-		"bar" : "baz",
+		"bar": "baz",
 	}
 
 	pod1 := v1.Pod{
@@ -31,24 +32,24 @@ func TestSecretStore(t *testing.T) {
 
 	secret1 := v1.Secret{
 		ObjectMeta: metaV1.ObjectMeta{
-			Labels:validLabels,
-			Name: "secret1",
+			Labels: validLabels,
+			Name:   "secret1",
 		},
 	}
 
 	secret2 := v1.Secret{
 		ObjectMeta: metaV1.ObjectMeta{
-			Labels:invalidLabels,
-			Name: "secret2",
+			Labels: invalidLabels,
+			Name:   "secret2",
 		},
 	}
 
-	_,err := client.CoreV1().Secrets("default").Create(&secret1)
+	_, err := client.CoreV1().Secrets("default").Create(&secret1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_,err = client.CoreV1().Secrets("default").Create(&secret2)
+	_, err = client.CoreV1().Secrets("default").Create(&secret2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,8 +60,8 @@ func TestSecretStore(t *testing.T) {
 	store.Add(&pod1)
 
 	cache := apiCache{
-		client: client,
-		secretStore:store,
+		client:      client,
+		secretStore: store,
 	}
 
 	filteredPods := cache.GetSecretsFilteredBy(validLabels)

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -92,7 +92,7 @@ func (s *store) GetBuilds() ([]*brigade.Build, error) {
 		b := NewBuildFromSecret(secretList.Items[i])
 		// The error is ErrWorkerNotFound, and in that case, we just ignore
 		// it and assign nil to the worker.
-		b.Worker, _ = findWorker(b.ID, podList)
+		b.Worker, _ = findWorker(b.ID, podList.Items)
 		buildList[i] = b
 	}
 	return buildList, nil
@@ -100,35 +100,35 @@ func (s *store) GetBuilds() ([]*brigade.Build, error) {
 
 // GetProjectBuilds returns all the builds for the given project.
 func (s *store) GetProjectBuilds(proj *brigade.Project) ([]*brigade.Build, error) {
-	// Load the pods that ran as part of this build.
-	lo := meta.ListOptions{LabelSelector: fmt.Sprintf("heritage=brigade,component=build,project=%s", proj.ID)}
 
-	secretList, err := s.client.CoreV1().Secrets(s.namespace).List(lo)
-	if err != nil {
-		return nil, err
+	// Load the pods that ran as part of this build.
+	labelSelectorMap := map[string]string{
+		"heritage":  "brigade",
+		"component": "build",
+		"project":   proj.ID,
 	}
+
+	projectSecrets := s.apiCache.GetSecretsFilteredBy(labelSelectorMap)
 
 	// The theory here is that the secrets and pods are close to 1:1, so we can
 	// preload the pods and take a local hit in walking the list rather than take
 	// a network hit to load each pod per secret.
-	podList, err := s.client.CoreV1().Pods(s.namespace).List(lo)
-	if err != nil {
-		return nil, err
-	}
+	projectPods := s.apiCache.GetPodsFilteredBy(labelSelectorMap)
 
-	buildList := make([]*brigade.Build, len(secretList.Items))
-	for i := range secretList.Items {
-		b := NewBuildFromSecret(secretList.Items[i])
+	buildList := make([]*brigade.Build, len(projectSecrets))
+	for i := range projectSecrets {
+		b := NewBuildFromSecret(projectSecrets[i])
 		// The error is ErrWorkerNotFound, and in that case, we just ignore
 		// it and assign nil to the worker.
-		b.Worker, _ = findWorker(b.ID, podList)
+		b.Worker, _ = findWorker(b.ID, projectPods)
 		buildList[i] = b
 	}
+
 	return buildList, nil
 }
 
-func findWorker(id string, pods *v1.PodList) (*brigade.Worker, bool) {
-	for _, i := range pods.Items {
+func findWorker(id string, pods []v1.Pod) (*brigade.Worker, bool) {
+	for _, i := range pods {
 		buildID, ok := i.Labels["build"]
 		if !ok {
 			continue

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -135,6 +135,10 @@ func TestGetBuilds(t *testing.T) {
 }
 
 func TestGetProjectBuilds(t *testing.T) {
+
+	// this could be related
+	// https://github.com/kubernetes/client-go/issues/352
+
 	k, s := fakeStore()
 	createFakeWorker(k, stubWorkerPod)
 	if err := s.CreateBuild(stubBuild); err != nil {

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/brigade/pkg/brigade"
+	"time"
 )
 
 func TestNewBuildFromSecret(t *testing.T) {
@@ -188,6 +189,9 @@ func TestGetProjectBuilds(t *testing.T) {
 	proj := &brigade.Project{
 		ID: stubProjectID,
 	}
+
+	// wait until api cache is synced
+	s.BlockUntilApiCacheSynced(time.After(time.Second))
 
 	builds, err := s.GetProjectBuilds(proj)
 	if err != nil {

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -7,8 +7,9 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/Azure/brigade/pkg/brigade"
 	"time"
+
+	"github.com/Azure/brigade/pkg/brigade"
 )
 
 func TestNewBuildFromSecret(t *testing.T) {
@@ -191,7 +192,7 @@ func TestGetProjectBuilds(t *testing.T) {
 	}
 
 	// wait until api cache is synced
-	s.BlockUntilApiCacheSynced(time.After(time.Second))
+	s.BlockUntilAPICacheSynced(time.After(time.Second))
 
 	builds, err := s.GetProjectBuilds(proj)
 	if err != nil {

--- a/pkg/storage/kube/store.go
+++ b/pkg/storage/kube/store.go
@@ -1,22 +1,24 @@
 package kube
 
 import (
+	"time"
+
 	"k8s.io/client-go/kubernetes"
+
 	"github.com/Azure/brigade/pkg/storage"
 	"github.com/Azure/brigade/pkg/storage/kube/apicache"
-	"time"
 )
 
 // store represents a storage engine for a brigade.Project.
 type store struct {
 	client    kubernetes.Interface
 	namespace string
-	apiCache  apicache.ApiCache
+	apiCache  apicache.APICache
 }
 
-// Blocks until the ApiCache is populated, useful for testing
-func (s *store)BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool{
-	return s.apiCache.BlockUntilApiCacheSynced(waitUntil)
+// BlockUntilAPICacheSynced blocks until the APICache is populated, useful for testing
+func (s *store) BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool {
+	return s.apiCache.BlockUntilAPICacheSynced(waitUntil)
 }
 
 // New initializes a new storage backend.
@@ -24,6 +26,6 @@ func New(c kubernetes.Interface, namespace string) storage.Store {
 	return &store{
 		client:    c,
 		namespace: namespace,
-		apiCache: apicache.New(c,namespace,time.Duration(60) * time.Second),
+		apiCache:  apicache.New(c, namespace, time.Duration(60)*time.Second),
 	}
 }

--- a/pkg/storage/kube/store.go
+++ b/pkg/storage/kube/store.go
@@ -14,6 +14,11 @@ type store struct {
 	apiCache  apicache.ApiCache
 }
 
+// Blocks until the ApiCache is populated, useful for testing
+func (s *store)BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool{
+	return s.apiCache.BlockUntilApiCacheSynced(waitUntil)
+}
+
 // New initializes a new storage backend.
 func New(c kubernetes.Interface, namespace string) storage.Store {
 	return &store{

--- a/pkg/storage/kube/store.go
+++ b/pkg/storage/kube/store.go
@@ -2,17 +2,23 @@ package kube
 
 import (
 	"k8s.io/client-go/kubernetes"
-
 	"github.com/Azure/brigade/pkg/storage"
+	"github.com/Azure/brigade/pkg/storage/kube/apicache"
+	"time"
 )
 
 // store represents a storage engine for a brigade.Project.
 type store struct {
 	client    kubernetes.Interface
 	namespace string
+	apiCache  apicache.ApiCache
 }
 
 // New initializes a new storage backend.
 func New(c kubernetes.Interface, namespace string) storage.Store {
-	return &store{c, namespace}
+	return &store{
+		client:    c,
+		namespace: namespace,
+		apiCache: apicache.New(c,namespace,time.Duration(60) * time.Second),
+	}
 }

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -8,9 +8,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"k8s.io/apimachinery/pkg/watch"
+
 	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage"
-	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (
@@ -140,9 +141,53 @@ var (
 	}
 )
 
+type fakeWatcher struct {
+	ch chan watch.Event
+}
+
+func (fakeWatcher) Stop() {}
+func (f *fakeWatcher) ResultChan() <-chan watch.Event {
+	return f.ch
+}
+
 // fakeStore returns a fake Kubernetes client and a *store that wraps it.
 func fakeStore() (kubernetes.Interface, storage.Store) {
+
 	client := fake.NewSimpleClientset()
+	/*client.AddWatchReactor("secrets", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+
+		ch := make(chan watch.Event)
+		go func(stubProjectSecret *v1.Secret) {
+			ch <- watch.Event{
+				Type:   watch.Added,
+				Object: stubProjectSecret,
+			}
+		}(stubProjectSecret)
+
+		return true, &fakeWatcher{
+			ch:ch,
+		}, nil
+	})
+
+	client.AddWatchReactor("pods", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+
+		ch := make(chan watch.Event)
+		go func(p1, p2 v1.Pod) {
+			ch <- watch.Event{
+				Type:   watch.Added,
+				Object: &p1,
+			}
+			ch <- watch.Event{
+				Type:   watch.Added,
+				Object: &p2,
+			}
+		}(stubJobPod, stubWorkerPod)
+
+		return true, &fakeWatcher{
+			ch:ch,
+		}, nil
+	})*/
+
 	return client, New(client, "default")
 }
 

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -152,42 +152,7 @@ func (f *fakeWatcher) ResultChan() <-chan watch.Event {
 
 // fakeStore returns a fake Kubernetes client and a *store that wraps it.
 func fakeStore() (kubernetes.Interface, storage.Store) {
-
 	client := fake.NewSimpleClientset()
-	/*client.AddWatchReactor("secrets", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
-
-		ch := make(chan watch.Event)
-		go func(stubProjectSecret *v1.Secret) {
-			ch <- watch.Event{
-				Type:   watch.Added,
-				Object: stubProjectSecret,
-			}
-		}(stubProjectSecret)
-
-		return true, &fakeWatcher{
-			ch:ch,
-		}, nil
-	})
-
-	client.AddWatchReactor("pods", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
-
-		ch := make(chan watch.Event)
-		go func(p1, p2 v1.Pod) {
-			ch <- watch.Event{
-				Type:   watch.Added,
-				Object: &p1,
-			}
-			ch <- watch.Event{
-				Type:   watch.Added,
-				Object: &p2,
-			}
-		}(stubJobPod, stubWorkerPod)
-
-		return true, &fakeWatcher{
-			ch:ch,
-		}, nil
-	})*/
-
 	return client, New(client, "default")
 }
 

--- a/pkg/storage/kube/store_test.go
+++ b/pkg/storage/kube/store_test.go
@@ -8,8 +8,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"k8s.io/apimachinery/pkg/watch"
-
 	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage"
 )
@@ -141,15 +139,6 @@ var (
 		Script:   []byte("ohai"),
 	}
 )
-
-type fakeWatcher struct {
-	ch chan watch.Event
-}
-
-func (fakeWatcher) Stop() {}
-func (f *fakeWatcher) ResultChan() <-chan watch.Event {
-	return f.ch
-}
 
 // fakeStore returns a fake Kubernetes client and a *store that wraps it.
 func fakeStore() (kubernetes.Interface, storage.Store) {

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -82,8 +82,8 @@ type Store struct {
 	LogData string
 }
 
-// the mocked store is declared to be in sync
-func (s *Store)BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool {
+// BlockUntilAPICacheSynced gets the mocked store is declared to be in sync
+func (s *Store) BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool {
 	return true
 }
 

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -82,6 +82,11 @@ type Store struct {
 	LogData string
 }
 
+// the mocked store is declared to be in sync
+func (s *Store)BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool {
+	return true
+}
+
 // GetProjects gets the mock project wrapped as a slice of projects.
 func (s *Store) GetProjects() ([]*brigade.Project, error) {
 	return []*brigade.Project{s.Project}, nil

--- a/pkg/storage/mock/storage_test.go
+++ b/pkg/storage/mock/storage_test.go
@@ -55,4 +55,8 @@ func TestStore(t *testing.T) {
 
 	wl, _ := m.GetWorkerLog(StubWorker)
 	assertSame("GetJobLog", StubLogData, wl)
+
+	if !m.BlockUntilApiCacheSynced(nil){
+		t.Fatal("expected to return true")
+	}
 }

--- a/pkg/storage/mock/storage_test.go
+++ b/pkg/storage/mock/storage_test.go
@@ -56,7 +56,7 @@ func TestStore(t *testing.T) {
 	wl, _ := m.GetWorkerLog(StubWorker)
 	assertSame("GetJobLog", StubLogData, wl)
 
-	if !m.BlockUntilApiCacheSynced(nil){
+	if !m.BlockUntilAPICacheSynced(nil) {
 		t.Fatal("expected to return true")
 	}
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/Azure/brigade/pkg/brigade"
+	"time"
 )
 
 // Store represents a storage engine for a Project.
@@ -34,4 +35,6 @@ type Store interface {
 	GetWorkerLog(job *brigade.Worker) (string, error)
 	// GetWorkerLogStream retrieve a stream of all logs for a worker from storage.
 	GetWorkerLogStream(job *brigade.Worker) (io.ReadCloser, error)
+	// This is useful e.g. for testing to indicate when the ApiCache is populated
+	BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -3,8 +3,9 @@ package storage
 import (
 	"io"
 
-	"github.com/Azure/brigade/pkg/brigade"
 	"time"
+
+	"github.com/Azure/brigade/pkg/brigade"
 )
 
 // Store represents a storage engine for a Project.
@@ -35,6 +36,6 @@ type Store interface {
 	GetWorkerLog(job *brigade.Worker) (string, error)
 	// GetWorkerLogStream retrieve a stream of all logs for a worker from storage.
 	GetWorkerLogStream(job *brigade.Worker) (io.ReadCloser, error)
-	// This is useful e.g. for testing to indicate when the ApiCache is populated
-	BlockUntilApiCacheSynced(waitUntil <- chan time.Time)bool
+	// BlockUntilAPICacheSynced signals when the cache is initially populated (useful e.g. for testing)
+	BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool
 }


### PR DESCRIPTION
This PR introduces api caching using the "k8s.io/client-go/tools/cache" package.
As a result of #433 I saw the necessity to optimize the route "/projects-build".

After not seeing any improvements via the "naive" implementation I've setup some benchmarks to analyse the problem.

I figured out that there were way too many requests towards the kubernetes api to fetch secrets, each of these was taking about 200ms.

The solution I'd like to introduce is caching all secrets of the brigade namespace for some reasonable time. This way there are zero network requests left during the invocation of "projects-build".

All in all this reduces the response time for our environment with a dozen pipelines from 10 seconds to 100ms.

Everything I touched is 100% covered.

I'm looking forward to getting this PR into the upstream.