### PR TITLE
feat(controller): allow per-project image pull secrets for worker

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -55,7 +55,8 @@ func TestController(t *testing.T) {
 		},
 		// This and the missing 'script' will trigger an initContainer
 		Data: map[string][]byte{
-			"vcsSidecar": []byte(sidecarImage),
+			"vcsSidecar":       []byte(sidecarImage),
+			"imagePullSecrets": []byte(`foo,bar`),
 		},
 	}
 
@@ -98,6 +99,18 @@ func TestController(t *testing.T) {
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
+	}
+
+	imgSecrets := pod.Spec.ImagePullSecrets
+	if len(imgSecrets) != 2 {
+		t.Fatal("expected two image pull secrets")
+	}
+
+	expectedNames := []string{"foo", "bar"}
+	for i, ips := range imgSecrets {
+		if ips.Name != expectedNames[i] {
+			t.Errorf("expected imagePullSecrets %q, got %q", expectedNames[i], ips.Name)
+		}
 	}
 
 	for i, term := range []string{"yarn", "-s", "start"} {

--- a/brigade-controller/cmd/brigade-controller/controller/handler.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler.go
@@ -150,6 +150,16 @@ func (c *Controller) newWorkerPod(build, project *v1.Secret) (v1.Pod, error) {
 			Env: env,
 		}}
 	}
+
+	if ips := project.Data["imagePullSecrets"]; len(ips) > 0 {
+		pullSecs := strings.Split(string(ips), ",")
+		refs := []v1.LocalObjectReference{}
+		for _, pullSec := range pullSecs {
+			ref := v1.LocalObjectReference{Name: strings.TrimSpace(pullSec)}
+			refs = append(refs, ref)
+		}
+		pod.Spec.ImagePullSecrets = refs
+	}
 	return pod, nil
 }
 

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -29,6 +29,9 @@ stringData:
   {{ if .Values.buildStorageSize }}
   buildStorageSize: {{ .Values.buildStorageSize | quote }}
   {{- end }}
+  {{ if .Values.imagePullSecrets }}
+  imagePullSecrets: {{ .Values.imagePullSecrets | quote }}
+  {{- end }}
   {{ if .Values.secrets }}
   secrets: '{{ .Values.secrets | toJson }}'
   {{- end }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -79,6 +79,12 @@ secrets:
 # be used.
 vcsSidecar: "deis/git-sidecar:latest"
 
+# OPTIONAL: imagePullSecrets allows you to specify a comma-separated list of
+# image pull secrets that will be injected into the worker. With this, you can
+# use a vcsSidecar or worker image from an internal repository.
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets: foo
+
 # OPTIONAL: buildStorageSize is the size of the shared storage space used by the jobs
 # buildStorageSize: "50Mi"
 


### PR DESCRIPTION
This adds a parameter to the project that allows projects to declare
image pull secrets for the vcsSidecar (and worker)

Closes #445 