### PR TITLE
Feature: Configmap as scriptstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 
 # Developer
 pvt/
+debug.test

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -20,6 +20,9 @@ stringData:
   defaultScript: |
 {{.Values.defaultScript | indent 4}}
   {{- end }}
+  {{ if .Values.defaultScriptName }}
+  defaultScriptName: {{ .Values.defaultScriptName | quote }}
+  {{- end }}
   {{ if eq "NONE" .Values.vcsSidecar -}}
   {{- else if empty .Values.vcsSidecar -}}
   vcsSidecar: {{ printf "deis/git-sidecar:%s" .Chart.Version }}

--- a/charts/brigade-project/values.yaml
+++ b/charts/brigade-project/values.yaml
@@ -11,6 +11,9 @@ cloneURL: "https://github.com/deis/empty-testbed.git"
 # OPTIONAL: initGitSubmodules will recursively initialize all submodules in the repository. Default: false
 # initGitSubmodules: "false"
 
+# OPTIONAL: defaultScriptName is the name of a configmap that contains the brigade.js to be used when your VCS repo misses a brigade.js
+# defaultScriptName: 
+
 # OPTIONAL: defaultScript is the brigade.js used by default when your VCS repo misses a brigade.js
 # in it.
 # defaultScript: |

--- a/charts/brigade/templates/controller-role.yaml
+++ b/charts/brigade/templates/controller-role.yaml
@@ -22,7 +22,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/brigade/templates/gateway-github-role.yaml
+++ b/charts/brigade/templates/gateway-github-role.yaml
@@ -23,7 +23,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
+  resources: ["secrets", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -30,6 +30,8 @@ type Project struct {
 	Secrets SecretsMap `json:"secrets"`
 	// Worker holds a set of project-specific worker settings which takes precedence over brigade-wide settings
 	Worker WorkerConfig `json:"worker"`
+	// DefaultScriptName is the name of the configmap where the script is stored. It is overriden by Repo script and takes precedence over DefaultScript
+	DefaultScriptName string `json:"defaultScriptName"`
 }
 
 // SecretsMap is a map[string]string for storing secrets.

--- a/pkg/storage/kube/configmap.go
+++ b/pkg/storage/kube/configmap.go
@@ -1,0 +1,22 @@
+package kube
+
+import (
+	"errors"
+	"log"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetScript retrieves brigade.js script from storage
+func (s *store) GetScript(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("Missing config map name")
+	}
+	configMap, err := s.client.CoreV1().ConfigMaps(s.namespace).Get(name, meta.GetOptions{})
+	if err != nil {
+		log.Printf("Error retrieving config map %s: %s", name, err)
+		return "", err
+	}
+	script := configMap.Data["brigade.js"]
+	return script, nil
+}

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -153,6 +153,11 @@ func (s *Store) CreateBuild(b *brigade.Build) error {
 	return nil
 }
 
+// GetScript fake
+func (s *Store) GetScript(name string) (string, error) {
+	return "", nil
+}
+
 // rc wraps a string in a ReadCloser.
 func rc(s string) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewBufferString(s))

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -38,4 +38,6 @@ type Store interface {
 	GetWorkerLogStream(job *brigade.Worker) (io.ReadCloser, error)
 	// BlockUntilAPICacheSynced signals when the cache is initially populated (useful e.g. for testing)
 	BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool
+	// GetScript retrieves brigade.js script from storage
+	GetScript(name string) (string, error)
 }


### PR DESCRIPTION
**Use case**: Keep generic brigade.js scripts in a common store when you wish to avoid duplicate defaultScript entries in multiple project configurations as well as in each repo.

**Solution**: Add optional property _defaultScriptName_ that refers to the name of a config map containing the brigade.js.
Order of precedence: repo > configmap > defaultscript

Scripts can then be stored by executing the following command:
```kubectl create cm mycommonscript --from-file=./brigade.js```