### PR TITLE
Docs update: `pull_request` fires `closed` event

### DIFF
--- a/docs/topics/github.md
+++ b/docs/topics/github.md
@@ -11,6 +11,7 @@ following events:
   - opened
   - reopened
   - synchronize
+  - closed
 - `pull_request:labeled`: Fired whenever a label is added to a pull request.
 - `pull_request:unlabeled`: Fired whenever a label is removed from a pull request.
 - `create`: Fired when a tag, branch, or repo is created.


### PR DESCRIPTION
Update the `github.md` file to include the `closed` event that was added in this commit: https://github.com/Azure/brigade/commit/3c9db0676ef3d832ab68df427339a220f1991143