### PR TITLE
feat(*): add project option for fallback script

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -190,7 +190,8 @@ func TestController_WithScript(t *testing.T) {
 		},
 		// This and the missing 'script' will trigger an initContainer
 		Data: map[string][]byte{
-			"vcsSidecar": []byte(sidecarImage),
+			"vcsSidecar":        []byte(sidecarImage),
+			"defaultScriptName": []byte("my-script"),
 		},
 	}
 
@@ -232,9 +233,11 @@ func TestController_WithScript(t *testing.T) {
 	if c.VolumeMounts[0].Name != volumeName {
 		t.Error("Container.VolumeMounts is not correct")
 	}
-
-	if l := len(pod.Spec.InitContainers); l != 0 {
-		t.Fatalf("Expected no init container, got %d", l)
+	if l := len(pod.Spec.InitContainers); l != 1 {
+		t.Fatalf("Expected 1 init container, got %d", l)
+	}
+	if l := len(pod.Spec.Containers[0].VolumeMounts); l != 3 {
+		t.Fatalf("Expected 3 volume mounts, got %d", l)
 	}
 }
 

--- a/charts/brigade-project/templates/secret.yaml
+++ b/charts/brigade-project/templates/secret.yaml
@@ -16,6 +16,9 @@ stringData:
   sharedSecret: {{ .Values.sharedSecret | quote }}
   cloneURL: {{ .Values.cloneURL | quote }}
   initGitSubmodules: {{ default "false" .Values.initGitSubmodules | quote }}
+  {{ if .Values.defaultScriptName }}
+  defaultScriptName: {{ .Values.defaultScriptName | quote }}
+  {{- end }}
   {{ if .Values.defaultScript }}
   defaultScript: |
 {{.Values.defaultScript | indent 4}}

--- a/charts/brigade/templates/controller-role.yaml
+++ b/charts/brigade/templates/controller-role.yaml
@@ -22,10 +22,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "secrets", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 kind: RoleBinding

--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -23,7 +23,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods", "secrets", "persistentvolumeclaims"]
+  resources: ["pods", "secrets", "persistentvolumeclaims", "configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods/log"]

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -20,6 +20,8 @@ type Project struct {
 	Repo Repo `json:"repo"`
 	// DefaultScript is a snippet of js used by default when the Repo misses brigade.js in it
 	DefaultScript string `json:"defaultScript"`
+	// DefaultScriptName is the name of the configmap where the script is stored.
+	DefaultScriptName string `json:"defaultScriptName"`
 	// Kubernetes holds information about Kubernetes
 	Kubernetes Kubernetes `json:"kubernetes"`
 	// SharedSecret is the GitHub shared key

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -62,6 +62,7 @@ func NewProjectFromSecret(secret *v1.Secret, namespace string) (*brigade.Project
 	proj.Kubernetes.VCSSidecar = sv.String("vcsSidecar")
 	proj.Kubernetes.BuildStorageSize = def(sv.String("buildStorageSize"), "50Mi")
 	proj.DefaultScript = sv.String("defaultScript")
+	proj.DefaultScriptName = sv.String("defaultScriptName")
 
 	proj.Repo = brigade.Repo{
 		Name: def(sv.String("repository"), proj.Name),

--- a/pkg/storage/kube/project_test.go
+++ b/pkg/storage/kube/project_test.go
@@ -41,6 +41,7 @@ func TestConfigureProject(t *testing.T) {
 		Data: map[string][]byte{
 			"repository":        []byte("myrepo"),
 			"defaultScript":     []byte(`console.log("hello default script")`),
+			"defaultScriptName": []byte("global-cm-script"),
 			"sharedSecret":      []byte("mysecret"),
 			"github.token":      []byte("like a fish needs a bicycle"),
 			"github.baseURL":    []byte("https://example.com/base"),
@@ -72,6 +73,9 @@ func TestConfigureProject(t *testing.T) {
 	}
 	if proj.DefaultScript != `console.log("hello default script")` {
 		t.Errorf("Unexpected DefaultScript: %q", proj.DefaultScript)
+	}
+	if proj.DefaultScriptName != "global-cm-script" {
+		t.Errorf("Unexpected DefaultScriptName: %q", proj.DefaultScriptName)
 	}
 	if proj.SharedSecret != "mysecret" {
 		t.Error("SharedSecret is not correct")

--- a/pkg/webhook/dockerhub.go
+++ b/pkg/webhook/dockerhub.go
@@ -13,16 +13,12 @@ import (
 )
 
 type dockerPushHook struct {
-	store   storage.Store
-	getFile fileGetter
+	store storage.Store
 }
 
 // NewDockerPushHook creates a new Docker Push handler for webhooks.
 func NewDockerPushHook(s storage.Store) gin.HandlerFunc {
-	h := &dockerPushHook{
-		store:   s,
-		getFile: getFileFromGithub,
-	}
+	h := &dockerPushHook{store: s}
 	return h.Handle
 }
 

--- a/pkg/webhook/dockerhub_test.go
+++ b/pkg/webhook/dockerhub_test.go
@@ -31,8 +31,7 @@ func TestDoDockerImagePush(t *testing.T) {
 	commit := "e1e10"
 	store := &testStore{}
 	hook := &dockerPushHook{
-		store:   store,
-		getFile: getFileFromGithub,
+		store: store,
 	}
 
 	if err := hook.doDockerImagePush(proj, commit, []byte(exampleWebhook)); err != nil {
@@ -50,10 +49,7 @@ func TestDoDockerImagePush_WithDefaultScript(t *testing.T) {
 
 	commit := "e1e10"
 	store := &testStore{}
-	hook := &dockerPushHook{
-		store:   store,
-		getFile: getFileFromGithub,
-	}
+	hook := &dockerPushHook{store: store}
 
 	if err := hook.doDockerImagePush(proj, commit, []byte(exampleWebhook)); err != nil {
 		t.Errorf("failed docker image push: %s", err)

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -15,19 +15,13 @@ import (
 	"github.com/Azure/brigade/pkg/storage"
 )
 
-const (
-	brigadeJSFile      = "brigade.js"
-	hubSignatureHeader = "X-Hub-Signature"
-)
+const hubSignatureHeader = "X-Hub-Signature"
 
 type githubHook struct {
 	store          storage.Store
-	getFile        fileGetter
 	createStatus   statusCreator
 	allowedAuthors []string
 }
-
-type fileGetter func(commit, path string, proj *brigade.Project) ([]byte, error)
 
 type statusCreator func(commit string, proj *brigade.Project, status *github.RepoStatus) error
 
@@ -35,7 +29,6 @@ type statusCreator func(commit string, proj *brigade.Project, status *github.Rep
 func NewGithubHook(s storage.Store, authors []string) gin.HandlerFunc {
 	gh := &githubHook{
 		store:          s,
-		getFile:        getFileFromGithub,
 		createStatus:   setRepoStatus,
 		allowedAuthors: authors,
 	}
@@ -227,26 +220,13 @@ func truncAt(str string, max int) string {
 	return str
 }
 
-func getFileFromGithub(commit, path string, proj *brigade.Project) ([]byte, error) {
-	return GetFileContents(proj, commit, path)
-}
-
 func (s *githubHook) build(eventType string, rev brigade.Revision, payload []byte, proj *brigade.Project) error {
-	brigadeScript, err := s.getFile(rev.Commit, brigadeJSFile, proj)
-	if err != nil {
-		if proj.DefaultScript == "" {
-			return fmt.Errorf("no brigade.js found in either project's defaultScript or the git repository: %v", err)
-		}
-		brigadeScript = []byte(proj.DefaultScript)
-	}
-
 	b := &brigade.Build{
 		ProjectID: proj.ID,
 		Type:      eventType,
 		Provider:  "github",
 		Revision:  &rev,
 		Payload:   payload,
-		Script:    brigadeScript,
 	}
 
 	return s.store.CreateBuild(b)

--- a/pkg/webhook/github_test.go
+++ b/pkg/webhook/github_test.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -45,9 +44,6 @@ func newTestGithubHandler(store storage.Store, t *testing.T) *githubHook {
 	return &githubHook{
 		store:          store,
 		allowedAuthors: []string{"OWNERS"},
-		getFile: func(commit, path string, proj *brigade.Project) ([]byte, error) {
-			return []byte(""), nil
-		},
 		createStatus: func(commit string, proj *brigade.Project, status *github.RepoStatus) error {
 			return nil
 		},
@@ -254,46 +250,6 @@ func TestGithubHandler_badevent(t *testing.T) {
 	}
 }
 
-func TestGithubHandler_WithDefaultScript(t *testing.T) {
-	store := newTestStore()
-	store.proj.DefaultScript = `console.log("hello default script")'`
-	s := newTestGithubHandler(store, t)
-	// Treat the repo to have no file, to eventually trigger the fall-back to the default script
-	s.getFile = failingFileGet
-
-	payloadFile := "testdata/github-push-payload.json"
-	event := "push"
-
-	payload, err := ioutil.ReadFile(payloadFile)
-	if err != nil {
-		t.Fatalf("failed to read testdata: %s", err)
-	}
-
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("POST", "", bytes.NewReader(payload))
-	if err != nil {
-		t.Fatalf("failed to create request: %s", err)
-	}
-	r.Header.Add("X-GitHub-Event", event)
-	r.Header.Add("X-Hub-Signature", SHA1HMAC([]byte("asdf"), payload))
-
-	ctx, _ := gin.CreateTestContext(w)
-	ctx.Request = r
-
-	s.Handle(ctx)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("unexpected error: %d\n%s", w.Code, w.Body.String())
-	}
-	if len(store.builds) != 1 {
-		t.Fatalf("expected exactly one build to be created, but there are %d", len(store.builds))
-	}
-	script := string(store.builds[0].Script)
-	if script != store.proj.DefaultScript {
-		t.Errorf("unexpected build script: %s", script)
-	}
-}
-
 func TestTruncAt(t *testing.T) {
 	if "foo" != truncAt("foo", 100) {
 		t.Fatal("modified string that was fine.")
@@ -306,9 +262,4 @@ func TestTruncAt(t *testing.T) {
 	if got := truncAt("foobar1", 6); got != "foo..." {
 		t.Errorf("Unexpected truncation of foobar1: %s", got)
 	}
-}
-
-// failingFileGet is a `fileGetter` which is useful for simulating a situation that the project repository to contain no file
-func failingFileGet(commit, path string, proj *brigade.Project) ([]byte, error) {
-	return []byte{}, fmt.Errorf("simulated \"missing file\" error for commit=%s, path=%s, proj.name=%s", commit, path, proj.Name)
 }


### PR DESCRIPTION
Add a global script as a fallback if the build is not provided one
directly or checked in to VCS.  The script is stored as a configmap and
specified in project.defaultScriptName.