### PR TITLE
Fix the check for data in prestart.js

### DIFF
--- a/brigade-worker/prestart.js
+++ b/brigade-worker/prestart.js
@@ -33,7 +33,7 @@ function loadScript() {
   for (let src of scripts) {
     if (fs.existsSync(src)) {
       var data = fs.readFileSync(src, 'utf8')
-      if (data == "") {
+      if (data != "") {
         return data
       }
     }


### PR DESCRIPTION
It appears to be a bug in `prestart.js` that only returns the script if the file is empty.