### PR TITLE
[WIP] Update the Node Kubernetes client to 0.2.1

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -31,7 +31,7 @@
     "typescript": "^2.4.2"
   },
   "dependencies": {
-    "@kubernetes/client-node": "^0.1.3",
+    "@kubernetes/client-node": "^0.2.1",
     "pretty-error": "^2.1.1",
     "ulid": "^0.2.0"
   }

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -2,17 +2,15 @@
 # yarn lockfile v1
 
 
-"@kubernetes/client-node@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.1.3.tgz#40b26bf6c3774cc36ac82065f1db42d9d15ca26f"
+"@kubernetes/client-node@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.2.1.tgz#3c33d03eada44c5898e2cebe9b59098ab07179d1"
   dependencies:
     base-64 "^0.1.0"
     bluebird "^3.3.5"
     byline "^5.0.0"
-    chai "^4.1.0"
     js-yaml "^3.5.2"
     jsonpath "^0.2.11"
-    mocha "^3.4.2"
     request "^2.72.0"
     shelljs "^0.7.8 "
     underscore "^1.8.3"


### PR DESCRIPTION
closes #488 

This PR upgrades the Node Kubernetes client to the latest version, which supports Kubernetes 1.9 and 1.10.

To test:

```
$ yarn install
$ yarn test
```

Do not merge yet, as this has only been tested locally and it needs be tested in a real deployment.

cc @technosophos 