### PR TITLE
Add log follows on worker and job Storage API

### DIFF
--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -53,7 +53,7 @@ var (
 		ExitCode:     0,
 		Status:       brigade.JobSucceeded,
 	}
-	// StubLogData is string data representing a log
+	// StubLogData is string data representing a log.
 	StubLogData = "Hello World"
 )
 
@@ -82,7 +82,7 @@ type Store struct {
 	LogData string
 }
 
-// BlockUntilAPICacheSynced gets the mocked store is declared to be in sync
+// BlockUntilAPICacheSynced gets the mocked store is declared to be in sync.
 func (s *Store) BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool {
 	return true
 }
@@ -107,7 +107,7 @@ func (s *Store) GetBuilds() ([]*brigade.Build, error) {
 	return []*brigade.Build{s.Build}, nil
 }
 
-// GetBuild gets the mock Build
+// GetBuild gets the mock Build.
 func (s *Store) GetBuild(id string) (*brigade.Build, error) {
 	return s.Build, nil
 }
@@ -127,14 +127,19 @@ func (s *Store) GetJob(id string) (*brigade.Job, error) {
 	return s.Job, nil
 }
 
-// GetJobLog gets the mock log data
+// GetJobLog gets the mock log data.
 func (s *Store) GetJobLog(j *brigade.Job) (string, error) {
 	return s.LogData, nil
 }
 
-// GetJobLogStream gets the mock log data as a readcloser
+// GetJobLogStream gets the mock log data as a readcloser.
 func (s *Store) GetJobLogStream(j *brigade.Job) (io.ReadCloser, error) {
 	return rc(s.LogData), nil
+}
+
+// GetJobLogStreamFollow gets the mock log data as a readcloser.
+func (s *Store) GetJobLogStreamFollow(j *brigade.Job) (io.ReadCloser, error) {
+	return s.GetJobLogStream(j)
 }
 
 // GetWorkerLog gets the mock log data.
@@ -145,6 +150,11 @@ func (s *Store) GetWorkerLog(w *brigade.Worker) (string, error) {
 // GetWorkerLogStream gets a readcloser of the mock log data.
 func (s *Store) GetWorkerLogStream(w *brigade.Worker) (io.ReadCloser, error) {
 	return rc(s.LogData), nil
+}
+
+// GetWorkerLogStreamFollow gets a readcloser of the mock log data.
+func (s *Store) GetWorkerLogStreamFollow(w *brigade.Worker) (io.ReadCloser, error) {
+	return s.GetWorkerLogStream(w)
 }
 
 // CreateBuild fakes a new build.

--- a/pkg/storage/mock/storage_test.go
+++ b/pkg/storage/mock/storage_test.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
@@ -53,8 +54,28 @@ func TestStore(t *testing.T) {
 	jl, _ := m.GetJobLog(StubJob)
 	assertSame("GetJobLog", StubLogData, jl)
 
+	jls, _ := m.GetJobLogStream(StubJob)
+	bjls := new(bytes.Buffer)
+	bjls.ReadFrom(jls)
+	assertSame("GetJobLogStream", StubLogData, bjls.String())
+
+	jlsf, _ := m.GetJobLogStreamFollow(StubJob)
+	bjlsf := new(bytes.Buffer)
+	bjlsf.ReadFrom(jlsf)
+	assertSame("GetJobLogStreamFollow", StubLogData, bjlsf.String())
+
 	wl, _ := m.GetWorkerLog(StubWorker)
-	assertSame("GetJobLog", StubLogData, wl)
+	assertSame("GetWorkerLog", StubLogData, wl)
+
+	wls, _ := m.GetWorkerLogStream(StubWorker)
+	bwls := new(bytes.Buffer)
+	bwls.ReadFrom(wls)
+	assertSame("GetWorkerLogStream", StubLogData, bwls.String())
+
+	wlsf, _ := m.GetWorkerLogStreamFollow(StubWorker)
+	bwlsf := new(bytes.Buffer)
+	bwlsf.ReadFrom(wlsf)
+	assertSame("GetWorkerLogStreamFollow", StubLogData, bwlsf.String())
 
 	if !m.BlockUntilAPICacheSynced(nil) {
 		t.Fatal("expected to return true")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -32,10 +32,14 @@ type Store interface {
 	GetJobLog(job *brigade.Job) (string, error)
 	// GetJobLogStream retrieve a stream of all logs for a job from storage.
 	GetJobLogStream(job *brigade.Job) (io.ReadCloser, error)
+	// GetJobLogStreamFollow retrieve a follow stream of all logs for a job from storage.
+	GetJobLogStreamFollow(job *brigade.Job) (io.ReadCloser, error)
 	// GetWorkerLog retrieves all logs for a worker from storage.
 	GetWorkerLog(job *brigade.Worker) (string, error)
 	// GetWorkerLogStream retrieve a stream of all logs for a worker from storage.
 	GetWorkerLogStream(job *brigade.Worker) (io.ReadCloser, error)
+	// GetWorkerLogStreamFollow retrieve a followed stream of all logs for a worker from storage.
+	GetWorkerLogStreamFollow(job *brigade.Worker) (io.ReadCloser, error)
 	// BlockUntilAPICacheSynced signals when the cache is initially populated (useful e.g. for testing)
 	BlockUntilAPICacheSynced(waitUntil <-chan time.Time) bool
 }


### PR DESCRIPTION
 Hi!

This PR adds 2 new methods to the `Storage` interface API. `Storage.GetJobLogStreamFollow` and `storage.GetWorkerLogStreamFollow`. Just adds the `follow` flag to Kubernetes so we retrieve an `io.ReadCloser` that will follow the logs.

I created 2 new methods instead of adding a flag on the `Get(Worker|Job)LogStream` methods so the API continues being compatible with the current users and doesn't break current usage.

I don't think that requires testing this part, just uses the client-go (that it's very well tested :heart:), without domain logic at all.

