### PR TITLE
Enable custom dependencies for the brigade worker

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.1.3",
+    "child-process-promise": "^2.2.1",
     "pretty-error": "^2.1.1",
     "ulid": "^0.2.0"
   }

--- a/brigade-worker/prestart.js
+++ b/brigade-worker/prestart.js
@@ -62,6 +62,7 @@ function addDeps() {
 function addYarn(arg) {
   return exec.exec(`yarn add ${arg}`, {})
     .catch(e => {
-      console.log(e);
+      console.error(e)
+      process.exit(1)
     });
 }

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -234,6 +234,14 @@ check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
+child-process-promise@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
+  dependencies:
+    cross-spawn "^4.0.2"
+    node-version "^1.0.0"
+    promise-polyfill "^6.0.1"
+
 cjson@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.2.1.tgz#73cd8aad65d9e1505f9af1744d3b79c1527682a5"
@@ -283,6 +291,13 @@ concat-map@0.0.1:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -619,6 +634,12 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
+is-thirteen@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-thirteen/-/is-thirteen-2.0.0.tgz#a2dbd0f5ab7e10a4d0186e9a0b24263224d3f9b1"
+  dependencies:
+    noop3 "^13.7.2"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -626,6 +647,10 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -771,6 +796,13 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+lru-cache@^4.0.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-error@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
@@ -838,12 +870,20 @@ nan@^2.3.3:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
+node-version@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.3.tgz#1081c87cce6d2dbbd61d0e51e28c287782678496"
+
 nomnom@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.5.2.tgz#f4345448a853cfbd5c0d26320f2477ab0526fe2f"
   dependencies:
     colors "0.5.x"
     underscore "1.1.x"
+
+noop3@^13.7.2:
+  version "13.8.1"
+  resolved "https://registry.yarnpkg.com/noop3/-/noop3-13.8.1.tgz#0ae6414b6d7de3b6d85055cd2a920c1a0d61ad6e"
 
 nth-check@~1.0.1:
   version "1.0.1"
@@ -902,6 +942,14 @@ pretty-error@^2.1.1:
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+promise-polyfill@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -1231,6 +1279,12 @@ websocket@^1.0.25:
     typedarray-to-buffer "^3.1.2"
     yaeti "^0.0.6"
 
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -1250,6 +1304,10 @@ wrappy@1:
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This PR enables adding custom dependencies you can `require` and use from `brigade.js`, without [creating a custom Brigade worker](https://github.com/Azure/brigade/blob/master/docs/topics/workers.md).

This works by adding your dependencies in a `brigade.json` file (similar to a `package.json` file). The file will be parsed by the pre-start script and its dependencies will be added to the worker's dependency tree.

To test this:

- build the worker image and use it as the `BRIGADE_WORKER_IMAGE` in your Brigade deployment (to quickly test this, you can directly `kubectl edit deployment` the Brigade controller and change the environment variable `BRIGADE_WORKER_IMAGE`. New workers created will be based on this image)

- create a new project with the following minimum (you can use [this repo](https://github.com/radu-matei/brigade-javascript-deps), as it contains exactly the following):

`brigade.json`:
```
{
    "dependencies": {
        "is-thirteen": "2.0.0"
    }
}
```

`brigade.js`:

```
const { events } = require("brigadier")
const is = require("is-thirteen");

events.on("exec", function (e, p) {
    console.log("is 13 thirteen? " + is(13).thirteen())
})
```

And then simply `brig run <project-id>` - you should see an output similar to:

```
$ brig run brigade-86959b08a89af5b6b83f0ace6d9030f1fdca7ed8ea0a296e27d72e
Event created. Waiting for worker pod named "brigade-worker-01cexrvrs08shcev26961cwd6n".
Started build 01cexrvrs08shcev26961cwd6n as "brigade-worker-01cexrvrs08shcev26961cwd6n"
installing is-thirteen@2.0.0
prestart: src/brigade.js written
[brigade] brigade-worker version: 0.14.0
[brigade:k8s] Creating PVC named brigade-worker-01cexrvrs08shcev26961cwd6n
is 13 thirteen? true
[brigade:app] after: default event handler fired
[brigade:app] beforeExit(2): destroying storage
[brigade:k8s] Destroying PVC named brigade-worker-01cexrvrs08shcev26961cwd6n
```


Things to consider before merging:

- for now, the dependencies _should_  point the exact version (and not use the tilde `~` and caret `^` to indicate semver compatible versions)

- right now, the Brigade's worker dependencies are:

```
  "dependencies": {
    "@kubernetes/client-node": "^0.1.3",
    "child-process-promise": "^2.2.1",
    "pretty-error": "^2.1.1",
    "ulid": "^0.2.0"
  },

  "devDependencies": {
    "@types/chai": "^4.0.1",
    "@types/mocha": "^2.2.41",
    "@types/node": "^8.0.14",
    "chai": "^4.1.0",
    "mocha": "5.2.0",
    "prettier": "^1.9.1",
    "rimraf": "^2.6.2",
    "ts-node": "^3.3.0",
    "typedoc": "^0.8.0",
    "typescript": "^2.4.2"
  }
``` 
When a custom dependency will be added, `yarn` will add it side-by-side with the worker's own dependencies. Things will fail if a user adds a custom dependency that conflicts with one of the worker's dependencies (or one if its dependencies). However, existing dependencies can already be used from inside `brigade.js`, the only real issue is the impossibility to use a different version of any of the dependencies above.

- security considerations - as the Brigade worker is capable of modifying the state of your cluster, be mindful of any external dependencies you add.
- for now, the only way to specify dependencies is through the `brigade.json` file at the root of the repository. 
- you can use the `brigade.json` file in any way you see fit, as the only part used is the `dependencies` node.
