### PR TITLE
fix(github): rolebinding resources

### DIFF
--- a/charts/brigade/templates/gateway-github-role.yaml
+++ b/charts/brigade/templates/gateway-github-role.yaml
@@ -25,6 +25,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "watch"]
 ---
 kind: RoleBinding
 apiVersion: {{ template "brigade.rbac.version" }}


### PR DESCRIPTION
Github GW shoud have permissions to watch and list pods

I had a next errors in logs
- for list:
```
E0608 23:58:24.777474       5 reflector.go:205] github.com/Azure/brigade/pkg/storage/kube/apicache/liststore.go:36: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:brigade:brigade-brigade-github-gw" cannot list pods in the namespace "brigade": Unknown user "system:serviceaccount:brigade:brigade-brigade-github-gw"
```
- for watch:
```
E0608 23:59:39.707864       5 reflector.go:315] github.com/Azure/brigade/pkg/storage/kube/apicache/liststore.go:36: Failed to watch *v1.Pod: unknown (get pods)
```