### PR TITLE
fix(docs): Job imagePullSecrets is a string array, not string

### DIFF
--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -180,7 +180,7 @@ Properties of `Job`
 - `tasks: string[]`: Tasks to be run in the job, in order.
 - `env: {[key: string]:string}`: Name/value pairs of environment variables.
 - `image: string`: The container image to run
-- `imagePullSecrets: string`: The names of the pull secrets (for pulling images from a secure remote repository)
+- `imagePullSecrets: string[]`: The names of the pull secrets (for pulling images from a secure remote repository)
 - `mountPath: string`: The path where any resources should be mounted (e.g. where a Git repository will be cloned) (defaults to `/src`)
 - `timeout: number`: Time to wait, in milliseconds, before the job is marked "failed"
 - `useSource: bool`: If false, no external resource will be loaded (e.g. no git clone will be performed)


### PR DESCRIPTION
The documentation stated that `imagePullSecrets` type is `string`, but it is `string[]` (array of strings).