### PR TITLE
docs(ux): navigation and installer help

### DIFF
--- a/brig/README.md
+++ b/brig/README.md
@@ -49,6 +49,8 @@ The output of the master process is written to STDOUT.
 To build Brig, clone the [Brigade repository](https://github.com/Azure/brigade)
 to `$GOPATH/src/github.com/Azure/brigade` and then run `make bootstrap brig`.
 
+If you have $GOPATH issues, you may need to [add the Brigade binary](https://github.com/Azure/brigade/issues/447) to your path.
+
 ## How Brig Works
 
 Brig uses your `$KUBECONFIG` to find out about your Kubernetes cluster. It then

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 # Brigade Documentation
 
-Everything you need to know about Brigade.
+Everything you need to know about Brigade.  
+Browse the docs here: [https://azure.github.io/brigade/](https://azure.github.io/brigade/)
 
 ## First Steps
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -37,16 +37,16 @@ builds. However, there are a few things that are much harder to do when running 
   what you are doing.
 - Other inbound services may also be limited by the same restriction.
 
-## Notes for Azure Container Services (ACS)
+## Notes for Azure Container Services (AKS)
 
-Brigade is well-tested on ACS Kubernetes. We recommend using at least Kubernetes 1.6.
+Brigade is well-tested on [AKS Kubernetes](https://docs.microsoft.com/en-us/azure/aks/). We recommend using at least Kubernetes 1.6.
 
-- It is recommended to use a Service with type LoadBalancer on ACS, which will generate
+- It is recommended to use a Service with type LoadBalancer on AKS, which will generate
   an Azure load balancer for you.
 - For caching and storage, we recommend creating an Azure Storage instance and
   creating a Persistent Volume and Storage Class that use the `AzureFile` driver.
 - You can use Azure Container Registry for private images, provided that you
-  add the ACR instance to the same Resource Group that ACS belongs to.
+  add the ACR instance to the same Resource Group that AKS belongs to.
 - ACR's webhooks can be used to trigger events, as they follow the DockerHub
   webhook format.
 - When configuring webhooks, it is recommended that you map a domain (via Azure's

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -26,6 +26,10 @@ The `EXTERNAL-IP` field is the IP address that external services, such as GitHub
 
 Note that this is just one way of configuring Brigade to receive inbound connections. Brigade itself does not care how traffic is routed to it. Those with operational knowledge of Kubernetes may wish to use another method of ingress routing.
 
+## Brig
+
+We recommend using [Brig](https://github.com/Azure/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](https://github.com/Azure/brigade/tree/master/brig) for [installation and usage] docs.
+
 ## Notes for Minikube
 
 You can run Brigade on [Minikube](https://github.com/kubernetes/minikube) for easy testing

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -52,3 +52,10 @@ Brigade is well-tested on [AKS Kubernetes](https://docs.microsoft.com/en-us/azur
 - When configuring webhooks, it is recommended that you map a domain (via Azure's
   DNS service or another DNS service) to your Load Balancer IP. GitHub and other
   webhook services seem to work better with DNS names than with IP addresses.
+
+---
+
+Prev: [Overview][overview] `|` Next: [Writing your first CI pipeline, Part 1][part1]
+
+[overview]: overview.md
+[part1]: tutorial01.md

--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -21,3 +21,9 @@ Brigade is a Kubernetes-native tool for doing event-driven scripting. Here's wha
     Docker images.
 
 Brigade is designed for teams. It is not a SaaS, nor does it require a legion of domain experts to configure and run it. Instead, it should be easy to install, configure, and maintain.
+
+---
+
+Prev: [Docs Index](../index.md) `|` Next: [Quickstart Guide][install]
+
+[install]: install.md

--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -103,7 +103,11 @@ Keep refreshing the page. You should see new UUIDs being generated every time yo
 
 When you’re comfortable with the application, read [part 2 of this tutorial][part2] to learn about pushing our application to GitHub.
 
+---
+
+Prev: [Quickstart Guide][part1] `|` Next: [Writing your first CI pipeline, Part 2][part2]
 
 [github]: https://github.com/Azure/brigade
 [install]: install.md
+[part1]: tutorial01.md
 [part2]: tutorial02.md

--- a/docs/intro/tutorial02.md
+++ b/docs/intro/tutorial02.md
@@ -59,6 +59,9 @@ There you have it! Your first Github repository, linked to your local git reposi
 
 When you’re comfortable with the git workflow, read [part 3 of this tutorial][part3] to learn about configuring our Github repository to test new features using Brigade.
 
+ ---
 
-[part1]: tutorial01.md
-[part3]: tutorial03.md
+ Prev: [Part 1][part1] `|` Next: [Part 3][part3]
+
+ [part1]: tutorial01.md
+ [part3]: tutorial03.md

--- a/docs/intro/tutorial03.md
+++ b/docs/intro/tutorial03.md
@@ -88,6 +88,9 @@ The next time you push to the repository, the webhook system should trigger a bu
 
 After configuring Brigade to test new features, read [part 4 of this tutorial][part4] to write a new feature to the uuid-generator project, which will trigger a test build using Brigade.
 
+---
+
+Prev: [Part 2][part2] `|` Next: [Part 4][part4]
 
 [part2]: tutorial02.md
 [part4]: tutorial04.md

--- a/docs/intro/tutorial04.md
+++ b/docs/intro/tutorial04.md
@@ -172,6 +172,9 @@ This concludes the basic tutorial. If you are familiar with Brigade and are inte
 
 You might also be scratching your head on what to [read next][readnext].
 
+---
+
+Prev: [Part 3][part3] `|` Next: [Next Steps][readnext]
 
 [efficient-pipelines]: writing-efficient-pipelines.md
 [part1]: tutorial01.md

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,3 @@
+# Brigade Documentation
+
+Browse the docs here: [https://azure.github.io/brigade/](https://azure.github.io/brigade/)


### PR DESCRIPTION
Suggesting a few edits to the docs, based on problems I ran into when running through the Intro and Brig guides:

* use of Index vs Readmes makes browsing harder - hence links to the [readable version](https://azure.github.io/brigade/) should be prominent
* navigational flow through docs is confusing, so I added more Prev/Next links to the intro pages
* I couldn't find the Brig docs, so I referenced them from the Install Guide
* when `make bootstrap brig` failed, I wasn't sure how to resolve. [this issue helped](https://github.com/Azure/brigade/issues/447), so I referenced it from the Brig docs