### PR TITLE
docs(README) update main docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ for Kubernetes.
 - Project-based management
 - Configurable event hooks
 - Easy construction of pipelines
-- Check out the [docs](/docs/index.md) to get started.
+- Check out the docs](https://azure.github.io/brigade/) to get started.
 
 [![asciicast](https://asciinema.org/a/JBsjOpah4nTBvjqDT5dAWvefG.png)](https://asciinema.org/a/JBsjOpah4nTBvjqDT5dAWvefG)
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -28,7 +28,7 @@ Note that this is just one way of configuring Brigade to receive inbound connect
 
 ## Brig
 
-We recommend using [Brig](https://github.com/Azure/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](https://github.com/Azure/brigade/tree/master/brig) for [installation and usage] docs.
+We recommend using [Brig](https://github.com/Azure/brigade/tree/master/brig), a command line tool for interacting with Brigade. Read the [Brig guide](https://github.com/Azure/brigade/tree/master/brig) for installation and usage docs.
 
 ## Notes for Minikube
 


### PR DESCRIPTION
Small follow up to #509 - to highlight the site at [https://azure.github.io/brigade](https://azure.github.io/brigade)

---

That site is  more navigable and user-friendly, so this updates the root README to use that as the
primary docs URL.