### PR TITLE
517: fix for job name error cause by mixed case job names

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -248,7 +248,7 @@ export abstract class Job {
         "job name must be letters, numbers, and '-', and must not start or end with '-'"
       );
     }
-    this.name = name;
+    this.name = name.toLocaleLowerCase();
     this.image = image;
     this.imageForcePull = imageForcePull;
     this.tasks = tasks || [];


### PR DESCRIPTION
This is a fix for issue #517. I opted to directly set the name to lowercase for the user rather than allow them to make a mistake