### PR TITLE
feat(worker): allow setting storage and cache paths

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -69,12 +69,10 @@ export class JobCache {
    */
   public size: string = "5Mi";
 
-  // future-proof Cache.path. For now we will hard-code it, but make it so that
-  // we can modify in the future.
-  private _path: string = brigadeCachePath;
-  public get path(): string {
-    return this._path;
-  }
+  // EXPERIMENTAL: Allow script authors to change this location.
+  // Before Brigade 0.15, this used a getter to prevent scripters from setting
+  // this path directly.
+  public path: string = brigadeCachePath;
 }
 
 /**
@@ -84,10 +82,10 @@ export class JobCache {
  */
 export class JobStorage {
   public enabled: boolean = false;
-  private _path: string = brigadeStoragePath;
-  public get path(): string {
-    return this._path;
-  }
+
+  // EXPERIMENTAL: Allow setting the path.
+  // Prior to Brigade 0.15, this was read-only.
+  public path: string = brigadeStoragePath;
 }
 
 /**

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -44,6 +44,14 @@ describe("job", function() {
         assert.equal(c.size, "5Mi", "size is 5mi");
       });
     });
+    describe("#setPath", function() {
+      it("correctly sets and gets path", function() {
+        let c = new JobCache();
+        assert.equal(c.path, brigadeCachePath, "Dir is /brigade/cache");
+        c.path = "/foo"
+        assert.equal(c.path, "/foo", "Assert dir is /foo");
+      });
+    });
   });
   describe("JobStorage", function() {
     describe("#constructor", function() {
@@ -55,6 +63,14 @@ describe("job", function() {
           "Dir is " + brigadeStoragePath
         );
         assert.isFalse(c.enabled, "disabled by default");
+      });
+    });
+    describe("#setPath", function() {
+      it("correctly sets and gets path", function() {
+        let s = new JobStorage();
+        assert.equal(s.path, brigadeStoragePath, "Dir is /brigade/cache");
+        s.path = "/foo"
+        assert.equal(s.path, "/foo", "Assert dir is /foo");
       });
     });
   });

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -300,6 +300,32 @@ describe("k8s", function() {
           assert.isTrue(foundCache, "expected cache volume claim found");
           assert.isTrue(foundStorage, "expected storage volume claim found");
         });
+        it("configures volumes with custom paths", function() {
+          j.cache.path = "/cache";
+          j.cache.enabled = true;
+          j.storage.path = "/storage";
+          j.storage.enabled = true;
+          let jr = new k8s.JobRunner(j, e, p);
+
+          let cname = `${p.name.replace(
+            /[.\/]/g,
+            "-"
+          )}-${j.name.toLowerCase()}`;
+          let foundCache = false;
+          let storageName = "build-storage";
+          let foundStorage = false;
+          for (let v of jr.runner.spec.containers[0].volumeMounts) {
+            if (v.name == cname) {
+              foundCache = true;
+              assert.equal(v.mountPath, "/cache");
+            } else if (v.name == storageName) {
+              foundStorage = true;
+              assert.equal(v.mountPath, "/storage");
+            }
+          }
+          assert.isTrue(foundCache, "expected cache volume mount found");
+          assert.isTrue(foundStorage, "expected storage volume mount found");
+        });
       });
       context("when the project has enabled host mounts", function() {
         beforeEach(function() {

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -213,7 +213,7 @@ Properties:
 - `size: string`: The size, defaults to `5Mi`. This value is only evaluated the first
   time a job is cached. To resize, the cache must be destroyed manually.
 - `path: string`: A read-only attribute returning path (in the container) in which the cache
-  is available.
+  is available. EXPERIMENTAL: Support for setting the path was added in Brigade 0.15.
 
 ### The `JobDockerMount` class
 
@@ -241,6 +241,7 @@ A `JobHost` object provides preferences for the host upon which the job is execu
    Build storage exposes a mounted volume at `/mnt/brigade/share` with storage that
    can be shared across jobs.
 - `path: string`: The read-only path to the shared storage from within the container.
+   EXPERIMENTAL: Support for setting the `path` was added in Brigade 0.15.
 
 ### The `KubernetesConfig` class
 


### PR DESCRIPTION
This allows `job.storage.path` and `job.cache.path` to be written in
scripts, rather than be hard coded.

I marked this as experimental in case we have to back this out. The main reason it was read-only at the beginning was to prevent confusion as to where things were mounted. But as #515 point out, the benefits of making this easily specifiable outweigh the risks, I think.

Closes #515