### PR TITLE
Add Swagger support to API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -97,8 +97,8 @@
 [[projects]]
   name = "github.com/emicklei/go-restful-openapi"
   packages = ["."]
-  revision = "60f3c22579aa3b998e4c6e902649760531ca03ca"
-  version = "v0.9.1"
+  revision = "51bf251d405ad1e23511fef0a2dbe40bc70ce2c6"
+  version = "v0.11.0"
 
 [[projects]]
   name = "github.com/ghodss/yaml"
@@ -611,6 +611,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6e7b33a7dc085e5b9232d996e849fb441fe9c95d90b9875fdc08b6089d6d78f1"
+  inputs-digest = "398fb4ee308a6546c0c0c1b766f3f617d028117fd44703c483b4987518a7cb3a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,30 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "2d3a6656c17a60b0815b7e06ab0be04eacb6e613"
-  version = "v0.16.0"
+  revision = "777200caa7fb8936aed0f12b1fd79af64cc83ec9"
+  version = "v0.24.0"
+
+[[projects]]
+  name = "github.com/Azure/brigade"
+  packages = [
+    "brig/cmd/brig/commands",
+    "brigade-controller/cmd/brigade-controller/controller",
+    "brigade-vacuum/cmd/brigade-vacuum/commands",
+    "brigade-vacuum/cmd/brigade-vacuum/vacuum",
+    "pkg/api",
+    "pkg/brigade",
+    "pkg/decolorizer",
+    "pkg/merge",
+    "pkg/portforwarder",
+    "pkg/storage",
+    "pkg/storage/kube",
+    "pkg/storage/kube/apicache",
+    "pkg/storage/mock",
+    "pkg/version",
+    "pkg/webhook"
+  ]
+  revision = "c683e76589f89abc1ffafd94595718ab501c2526"
+  version = "v0.15.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -15,14 +37,26 @@
     "autorest/azure",
     "autorest/date"
   ]
-  revision = "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-  version = "v8.0.0"
+  revision = "1f7cd6cfe0adea687ad44a512dfe76140f804318"
+  version = "v10.12.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/Masterminds/kitt"
   packages = ["progress"]
   revision = "7e843d5f21a5f009f5119a91ea3868eabb19b20f"
+
+[[projects]]
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   name = "github.com/bacongobbler/browser"
@@ -33,12 +67,14 @@
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "782f4967f2dc4564575ca782fe2d04090b5faca8"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  revision = "01aeca54ebda6e0fbfafd0a524d234159c05ec20"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
   branch = "master"
@@ -50,9 +86,25 @@
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
+  name = "github.com/emicklei/go-restful"
+  packages = [
+    ".",
+    "log"
+  ]
+  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
+  version = "v2.8.0"
+
+[[projects]]
+  name = "github.com/emicklei/go-restful-openapi"
+  packages = ["."]
+  revision = "60f3c22579aa3b998e4c6e902649760531ca03ca"
+  version = "v0.9.1"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -64,10 +116,34 @@
   name = "github.com/gin-gonic/gin"
   packages = [
     "binding",
-    "json",
     "render"
   ]
-  revision = "d39ed41ab3795346f5f843ec31bc0138be07eaab"
+  revision = "d459835d2b077e44f7c9b453505ee29881d5d12d"
+  version = "v1.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
@@ -75,12 +151,14 @@
     "proto",
     "sortkeys"
   ]
-  revision = "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
+  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
+  version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/golang/glog"
   packages = ["."]
-  revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -91,13 +169,14 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
   revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
+  version = "v15.0.0"
 
 [[projects]]
   branch = "master"
@@ -106,9 +185,10 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
+  branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
@@ -117,9 +197,11 @@
     "compiler",
     "extensions"
   ]
-  revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
+  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
+  version = "v0.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -130,7 +212,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
+  revision = "45c2d035713fa44f366921035a44610ac5d45beb"
 
 [[projects]]
   branch = "master"
@@ -143,12 +225,13 @@
   revision = "36ee7e946282a3fb1cfecd476ddc9b35d8847e42"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru"
   ]
-  revision = "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
@@ -159,7 +242,8 @@
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
+  revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
+  version = "v0.3.5"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -170,20 +254,42 @@
 [[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "36b14963da70d11297d313183d7e6388c8510e1e"
-  version = "1.0.0"
+  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
+  version = "1.1.4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
+  revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  revision = "fc9e8d8ef48496124e79ae0df75490096eccf6fe"
-  version = "v0.0.2"
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  revision = "d6bea18f789704b5f83375793155289da36a3c7f"
-  version = "v0.0.1"
+  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
+  version = "v0.0.2"
+
+[[projects]]
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   name = "github.com/oklog/ulid"
@@ -194,36 +300,42 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "f62e98d28ab7ad31d707ba837a966378465c7b57"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
+  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
+  version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "81e90905daefcd6fd217b62423c0908922eadb30"
+  revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
+    "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
-    "lex/httplex"
+    "idna"
   ]
-  revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
+  revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -232,30 +344,38 @@
     "jws",
     "jwt"
   ]
-  revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+  revision = "ef147856a6ddbb60760db74283d2424e98c87bff"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows"
   ]
-  revision = "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
+  revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
     "internal/gen",
+    "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "language",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
+    "width"
   ]
-  revision = "b19bf474d317b857955b12035d2c5acb57ce8b01"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
@@ -277,7 +397,8 @@
     "internal/urlfetch",
     "urlfetch"
   ]
-  revision = "12d5545dc1cfa6047a286d5e853841b6471f4c19"
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [[projects]]
   name = "gopkg.in/gin-gonic/gin.v1"
@@ -288,19 +409,20 @@
 [[projects]]
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
-  revision = "5f57d2222ad794d0dffb07e664ea05e2ee07d60c"
-  version = "v8.18.1"
+  revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
+  version = "v8.18.2"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
-  version = "v0.9.0"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "53feefa2559fb8dfa8d81baad31be332c97d6c77"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [[projects]]
   branch = "release-1.10"
@@ -383,7 +505,7 @@
     "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect"
   ]
-  revision = "17529ec7eadb8de8e7dc835201455f53571f655a"
+  revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
 
 [[projects]]
   branch = "release-7.0"
@@ -484,11 +606,11 @@
     "util/retry",
     "util/workqueue"
   ]
-  revision = "26a26f55b28aa1b338fbaf6fbbe0bcd76aed05e0"
+  revision = "a312bfe35c401f70e5ea0add48b50da283031dc3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ce868ba487d6ca0774ce548894d8caabcc197e7c0e932921298711b40e49282d"
+  inputs-digest = "6e7b33a7dc085e5b9232d996e849fb441fe9c95d90b9875fdc08b6089d6d78f1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,8 +41,8 @@
 
 [[constraint]]
   name = "github.com/emicklei/go-restful"
-  version = "2.6.1"
+  version = "2.7.1"
 
 [[constraint]]
   name = "github.com/emicklei/go-restful-openapi"
-  version = "0.9.1"
+  version = "0.11.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,3 +38,11 @@
 [[constraint]]
   branch = "master"
   name = "github.com/Masterminds/kitt"
+
+[[constraint]]
+  name = "github.com/emicklei/go-restful"
+  version = "2.6.1"
+
+[[constraint]]
+  name = "github.com/emicklei/go-restful-openapi"
+  version = "0.9.1"

--- a/brigade-api/cmd/brigade-api/filter.go
+++ b/brigade-api/cmd/brigade-api/filter.go
@@ -22,11 +22,11 @@ var (
 	disableColor = false
 )
 
-var logger *log.Logger = log.New(os.Stdout, "", 0)
+var logger = log.New(os.Stdout, "", 0)
 
 // NCSACommonLogFormatLogger Create a filter that produces log lines
 // according to the Common Log Format, also known as the NCSA standard.
-// Coloring inspired by gin
+// Coloring inspired by ansi
 func NCSACommonLogFormatLogger() restful.FilterFunction {
 	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		var username = "-"
@@ -40,10 +40,16 @@ func NCSACommonLogFormatLogger() restful.FilterFunction {
 		if err != nil {
 			return
 		}
+		isTerm := true
+		if disableColor {
+			isTerm = false
+		}
 		var statusColor, methodColor, resetColor string
-		methodColor = colorForMethod(req.Request.Method)
-		resetColor = reset
-		statusColor = colorForStatus(resp.StatusCode())
+		if isTerm {
+			methodColor = colorForMethod(req.Request.Method)
+			resetColor = reset
+			statusColor = colorForStatus(resp.StatusCode())
+		}
 		logger.Printf("%15s - %s [%s] \"%s %7s %s %s %s\" %s %3d %s %d",
 			ip,
 			username,
@@ -55,13 +61,6 @@ func NCSACommonLogFormatLogger() restful.FilterFunction {
 			resp.ContentLength(),
 		)
 	}
-}
-
-// MeasureTime web-service (post-process) Filter (as a struct that defines a FilterFunction)
-func MeasureTime(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	now := time.Now()
-	chain.ProcessFilter(req, resp)
-	logger.Printf("[webservice-filter (timer)] %v\n", time.Now().Sub(now))
 }
 
 func colorForMethod(method string) string {

--- a/brigade-api/cmd/brigade-api/filter.go
+++ b/brigade-api/cmd/brigade-api/filter.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	restful "github.com/emicklei/go-restful"
+)
+
+var (
+	green        = string([]byte{27, 91, 57, 55, 59, 52, 50, 109})
+	white        = string([]byte{27, 91, 57, 48, 59, 52, 55, 109})
+	yellow       = string([]byte{27, 91, 57, 55, 59, 52, 51, 109})
+	red          = string([]byte{27, 91, 57, 55, 59, 52, 49, 109})
+	blue         = string([]byte{27, 91, 57, 55, 59, 52, 52, 109})
+	magenta      = string([]byte{27, 91, 57, 55, 59, 52, 53, 109})
+	cyan         = string([]byte{27, 91, 57, 55, 59, 52, 54, 109})
+	reset        = string([]byte{27, 91, 48, 109})
+	disableColor = false
+)
+
+var logger *log.Logger = log.New(os.Stdout, "", 0)
+
+// NCSACommonLogFormatLogger Create a filter that produces log lines
+// according to the Common Log Format, also known as the NCSA standard.
+// Coloring inspired by gin
+func NCSACommonLogFormatLogger() restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		var username = "-"
+		if req.Request.URL.User != nil {
+			if name := req.Request.URL.User.Username(); name != "" {
+				username = name
+			}
+		}
+		chain.ProcessFilter(req, resp)
+		ip, _, err := net.SplitHostPort(strings.TrimSpace(req.Request.RemoteAddr))
+		if err != nil {
+			return
+		}
+		var statusColor, methodColor, resetColor string
+		methodColor = colorForMethod(req.Request.Method)
+		resetColor = reset
+		statusColor = colorForStatus(resp.StatusCode())
+		logger.Printf("%15s - %s [%s] \"%s %7s %s %s %s\" %s %3d %s %d",
+			ip,
+			username,
+			time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+			methodColor, req.Request.Method, resetColor,
+			req.Request.URL.RequestURI(),
+			req.Request.Proto,
+			statusColor, resp.StatusCode(), resetColor,
+			resp.ContentLength(),
+		)
+	}
+}
+
+// MeasureTime web-service (post-process) Filter (as a struct that defines a FilterFunction)
+func MeasureTime(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	now := time.Now()
+	chain.ProcessFilter(req, resp)
+	logger.Printf("[webservice-filter (timer)] %v\n", time.Now().Sub(now))
+}
+
+func colorForMethod(method string) string {
+	switch method {
+	case "GET":
+		return blue
+	case "POST":
+		return cyan
+	case "PUT":
+		return yellow
+	case "DELETE":
+		return red
+	case "PATCH":
+		return green
+	case "HEAD":
+		return magenta
+	case "OPTIONS":
+		return white
+	default:
+		return reset
+	}
+}
+
+func colorForStatus(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return green
+	case code >= 300 && code < 400:
+		return white
+	case code >= 400 && code < 500:
+		return yellow
+	default:
+		return red
+	}
+}

--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -3,14 +3,21 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
-	gin "gopkg.in/gin-gonic/gin.v1"
-	"k8s.io/api/core/v1"
+	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/Azure/brigade/pkg/storage/kube"
+	"github.com/emicklei/go-restful"
+	restfulspec "github.com/emicklei/go-restful-openapi"
 
 	"github.com/Azure/brigade/pkg/api"
-	"github.com/Azure/brigade/pkg/storage/kube"
+	"github.com/go-openapi/spec"
+	"k8s.io/api/core/v1"
 )
 
 var (
@@ -27,6 +34,159 @@ func init() {
 	flag.StringVar(&apiPort, "api-port", defaultAPIPort(), "TCP port to use for brigade-api")
 }
 
+type jobService struct {
+	server api.API
+}
+
+type buildService struct {
+	server api.API
+}
+
+type projectService struct {
+	server api.API
+}
+
+type healthService struct {
+}
+
+func (js jobService) WebService() *restful.WebService {
+	ws := new(restful.WebService)
+	j := js.server.Job()
+	// rest.GET("/job/:id", j.Get)
+	// rest.GET("/job/:id/logs", j.Logs)
+	ws.
+		Path("/v1/job").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	tags := []string{"job"}
+
+	ws.Route(ws.GET("/{id}").To(j.Get).
+		Doc("get a job").
+		Param(ws.PathParameter("id", "identifier of the job").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(brigade.Job{}). // on the response
+		Returns(200, "OK", brigade.Job{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/{id}/logs").To(j.Logs).
+		Doc("get job logs").
+		Param(ws.PathParameter("id", "identifier of the job").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]byte{}). // on the response
+		Returns(200, "OK", []byte{}).
+		Returns(404, "Not Found", nil))
+
+	return ws
+}
+
+func (bs buildService) WebService() *restful.WebService {
+	ws := new(restful.WebService)
+	b := bs.server.Build()
+	// rest.GET("/build/:id", b.Get)
+	// rest.GET("/build/:id/jobs", b.Jobs)
+	// rest.GET("/build/:id/logs", b.Logs)
+	ws.
+		Path("/v1/build").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	tags := []string{"build"}
+
+	ws.Route(ws.GET("/{id}").To(b.Get).
+		Doc("get a build").
+		Param(ws.PathParameter("id", "id of the build").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(brigade.Build{}).
+		Returns(200, "OK", brigade.Build{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/{id}/jobs").To(b.Jobs).
+		Doc("get jobs of a build").
+		Param(ws.PathParameter("id", "id of the build").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]brigade.Job{}).
+		Returns(200, "OK", []brigade.Job{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/{id}/logs").To(b.Logs).
+		Doc("get logs of a build").
+		Param(ws.PathParameter("id", "id of the build").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]byte{}).
+		Returns(200, "OK", []byte{}).
+		Returns(404, "Not Found", nil))
+
+	return ws
+}
+
+func (ps projectService) WebService() *restful.WebService {
+	ws := new(restful.WebService)
+	p := ps.server.Project()
+	// rest.GET("/projects", p.List)
+	// rest.GET("/project/:id", p.Get)
+	// rest.GET("/project/:id/builds", p.Builds)
+	// rest.GET("/projects-build", p.ListWithLatestBuild)
+	ws.
+		Path("/v1").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	tags := []string{"projects"}
+
+	ws.Route(ws.GET("/projects").To(p.List).
+		Doc("get all projects").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]brigade.Project{}).
+		Returns(200, "OK", []brigade.Project{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/project/{id}").To(p.Get).
+		Param(ws.PathParameter("id", "id of the project").DataType("string")).
+		Doc("get a project").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(brigade.Project{}).
+		Returns(200, "OK", brigade.Project{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/project/{id}/builds").To(p.Builds).
+		Doc("get list of builds for a project").
+		Param(ws.PathParameter("id", "id of the project").DataType("string")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]brigade.Build{}).
+		Returns(200, "OK", []brigade.Build{}).
+		Returns(404, "Not Found", nil))
+
+	ws.Route(ws.GET("/projects-build").To(p.ListWithLatestBuild).
+		Doc("lists the projects with the latest builds attached.").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]api.ProjectBuildSummary{}).
+		Returns(200, "OK", []api.ProjectBuildSummary{}).
+		Returns(404, "Not Found", nil))
+
+	return ws
+}
+
+func (hs healthService) WebService() *restful.WebService {
+	ws := new(restful.WebService)
+
+	ws.
+		Path("/v1/healthz").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	tags := []string{"healthz"}
+
+	ws.Route(ws.GET("/").To(api.Healthz).
+		Doc("get health status").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes([]byte{}).
+		Returns(200, "OK", []byte{}).
+		Returns(404, "Not Found", nil))
+
+	return ws
+}
+
 func main() {
 	flag.Parse()
 	clientset, err := kube.GetClient(master, kubeconfig)
@@ -36,34 +196,49 @@ func main() {
 	}
 
 	storage := kube.New(clientset, namespace)
-
-	router := gin.New()
-	router.Use(gin.Recovery())
-
-	// get an individual project
-	rest := router.Group("/v1")
-	rest.Use(gin.Logger(), cors)
 	server := api.New(storage)
 
-	p := server.Project()
-	rest.GET("/projects", p.List)
-	rest.GET("/project/:id", p.Get)
-	rest.GET("/project/:id/builds", p.Builds)
-	rest.GET("/projects-build", p.ListWithLatestBuild)
+	// router.GET("/healthz", api.Healthz)
+	j := jobService{server}
+	b := buildService{server}
+	p := projectService{server}
+	h := healthService{}
 
-	b := server.Build()
-	rest.GET("/build/:id", b.Get)
-	rest.GET("/build/:id/jobs", b.Jobs)
-	rest.GET("/build/:id/logs", b.Logs)
+	restful.DefaultContainer.Add(j.WebService())
+	restful.DefaultContainer.Add(b.WebService())
+	restful.DefaultContainer.Add(p.WebService())
+	restful.DefaultContainer.Add(h.WebService())
+	restful.DefaultContainer.Filter(nCSACommonLogFormatLogger())
 
-	j := server.Job()
-	rest.GET("/job/:id", j.Get)
-	rest.GET("/job/:id/logs", j.Logs)
+	config := restfulspec.Config{
+		WebServices: restful.RegisteredWebServices(), // you control what services are visible
+		APIPath:     "/apidocs.json",
+		PostBuildSwaggerObjectHandler: enrichSwaggerObject}
+	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(config))
 
-	router.GET("/healthz", api.Healthz)
+	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
+	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
+	// Open http://localhost:8080/apidocs/?url=http://localhost:8080/apidocs.json
+	//http.Handle("/apidocs/", http.StripPrefix("/apidocs/", http.FileServer(http.Dir("/swagger-ui/dist"))))
+
+	// Optionally, you may need to enable CORS for the UI to work.
+	cors := restful.CrossOriginResourceSharing{
+		AllowedHeaders: []string{"Content-Type", "Accept"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE"},
+		CookiesAllowed: false,
+		Container:      restful.DefaultContainer}
+	restful.DefaultContainer.Filter(cors.Filter)
 
 	formattedAPIPort := fmt.Sprintf(":%v", apiPort)
-	log.Fatal(router.Run(formattedAPIPort))
+
+	log.Printf("Get the API using %s/apidocs.json", formattedAPIPort)
+	hserver := &http.Server{Addr: formattedAPIPort, Handler: restful.DefaultContainer}
+	log.Fatal(hserver.ListenAndServe())
+	//log.Fatal(http.ListenAndServe(formattedAPIPort, nil))
+}
+
+func hello(req *restful.Request, resp *restful.Response) {
+	io.WriteString(resp, "world")
 }
 
 func defaultNamespace() string {
@@ -80,6 +255,43 @@ func defaultAPIPort() string {
 	return "7745"
 }
 
-func cors(c *gin.Context) {
-	c.Header("access-control-allow-origin", "*")
+func enrichSwaggerObject(swo *spec.Swagger) {
+	swo.Info = &spec.Info{
+		InfoProps: spec.InfoProps{
+			Title:       "Brigade API",
+			Description: "Resources for Jobs, Projects, Builds",
+			License: &spec.License{
+				Name: "MIT",
+				URL:  "http://mit.org",
+			},
+			Version: "1.0.0",
+		},
+	}
+	swo.Tags = []spec.Tag{spec.Tag{TagProps: spec.TagProps{
+		Name:        "brigade",
+		Description: "Brigade"}}}
+}
+
+var logger *log.Logger = log.New(os.Stdout, "", 0)
+
+func nCSACommonLogFormatLogger() restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		var username = "-"
+		if req.Request.URL.User != nil {
+			if name := req.Request.URL.User.Username(); name != "" {
+				username = name
+			}
+		}
+		chain.ProcessFilter(req, resp)
+		logger.Printf("%s - %s [%s] \"%s %s %s\" %d %d",
+			strings.Split(req.Request.RemoteAddr, ":")[0],
+			username,
+			time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+			req.Request.Method,
+			req.Request.URL.RequestURI(),
+			req.Request.Proto,
+			resp.StatusCode(),
+			resp.ContentLength(),
+		)
+	}
 }

--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -57,7 +56,7 @@ func (js jobService) WebService() *restful.WebService {
 	ws.
 		Path("/v1/job").
 		Consumes(restful.MIME_JSON).
-		Produces(restful.MIME_JSON)
+		Produces(restful.MIME_JSON, restful.MIME_XML, "plain/text", "text/javascript")
 
 	tags := []string{"job"}
 
@@ -89,7 +88,7 @@ func (bs buildService) WebService() *restful.WebService {
 	ws.
 		Path("/v1/build").
 		Consumes(restful.MIME_JSON).
-		Produces(restful.MIME_JSON)
+		Produces(restful.MIME_JSON, restful.MIME_XML, "plain/text", "text/javascript")
 
 	tags := []string{"build"}
 
@@ -130,7 +129,7 @@ func (ps projectService) WebService() *restful.WebService {
 	ws.
 		Path("/v1").
 		Consumes(restful.MIME_JSON).
-		Produces(restful.MIME_JSON)
+		Produces(restful.MIME_JSON, restful.MIME_XML, "plain/text", "text/javascript")
 
 	tags := []string{"projects"}
 
@@ -171,7 +170,7 @@ func (hs healthService) WebService() *restful.WebService {
 	ws := new(restful.WebService)
 
 	ws.
-		Path("/v1/healthz").
+		Path("/healthz").
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 
@@ -198,7 +197,6 @@ func main() {
 	storage := kube.New(clientset, namespace)
 	server := api.New(storage)
 
-	// router.GET("/healthz", api.Healthz)
 	j := jobService{server}
 	b := buildService{server}
 	p := projectService{server}
@@ -234,11 +232,6 @@ func main() {
 	log.Printf("Get the API using %s/apidocs.json", formattedAPIPort)
 	hserver := &http.Server{Addr: formattedAPIPort, Handler: restful.DefaultContainer}
 	log.Fatal(hserver.ListenAndServe())
-	//log.Fatal(http.ListenAndServe(formattedAPIPort, nil))
-}
-
-func hello(req *restful.Request, resp *restful.Response) {
-	io.WriteString(resp, "world")
 }
 
 func defaultNamespace() string {

--- a/brigade-api/cmd/brigade-api/main.go
+++ b/brigade-api/cmd/brigade-api/main.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage/kube"
@@ -206,7 +204,7 @@ func main() {
 	restful.DefaultContainer.Add(b.WebService())
 	restful.DefaultContainer.Add(p.WebService())
 	restful.DefaultContainer.Add(h.WebService())
-	restful.DefaultContainer.Filter(nCSACommonLogFormatLogger())
+	restful.DefaultContainer.Filter(NCSACommonLogFormatLogger())
 
 	config := restfulspec.Config{
 		WebServices: restful.RegisteredWebServices(), // you control what services are visible
@@ -263,28 +261,4 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 	swo.Tags = []spec.Tag{spec.Tag{TagProps: spec.TagProps{
 		Name:        "brigade",
 		Description: "Brigade"}}}
-}
-
-var logger *log.Logger = log.New(os.Stdout, "", 0)
-
-func nCSACommonLogFormatLogger() restful.FilterFunction {
-	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-		var username = "-"
-		if req.Request.URL.User != nil {
-			if name := req.Request.URL.User.Username(); name != "" {
-				username = name
-			}
-		}
-		chain.ProcessFilter(req, resp)
-		logger.Printf("%s - %s [%s] \"%s %s %s\" %d %d",
-			strings.Split(req.Request.RemoteAddr, ":")[0],
-			username,
-			time.Now().Format("02/Jan/2006:15:04:05 -0700"),
-			req.Request.Method,
-			req.Request.URL.RequestURI(),
-			req.Request.Proto,
-			resp.StatusCode(),
-			resp.ContentLength(),
-		)
-	}
 }

--- a/pkg/api/healthz.go
+++ b/pkg/api/healthz.go
@@ -3,10 +3,10 @@ package api
 import (
 	"net/http"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	restful "github.com/emicklei/go-restful"
 )
 
 // Healthz is the gin handler for the GET /healthz endpoint
-func Healthz(c *gin.Context) {
-	c.String(http.StatusOK, http.StatusText(http.StatusOK))
+func Healthz(request *restful.Request, response *restful.Response) {
+	response.WriteHeaderAndEntity(http.StatusOK, http.StatusText(http.StatusOK))
 }

--- a/pkg/api/job.go
+++ b/pkg/api/job.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/Azure/brigade/pkg/storage"
+
 	restful "github.com/emicklei/go-restful"
 )
 

--- a/pkg/api/project.go
+++ b/pkg/api/project.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	restful "github.com/emicklei/go-restful"
 
 	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage"
@@ -15,13 +15,13 @@ type Project struct {
 }
 
 // List creates a new gin handler for the GET /projects endpoint
-func (api Project) List(c *gin.Context) {
+func (api Project) List(request *restful.Request, response *restful.Response) {
 	projects, err := api.store.GetProjects()
 	if err != nil {
-		c.JSON(http.StatusNotFound, struct{}{})
+		response.WriteErrorString(http.StatusNotFound, "No Projects found.")
 		return
 	}
-	c.JSON(http.StatusOK, projects)
+	response.WriteHeaderAndEntity(http.StatusOK, projects)
 }
 
 // ProjectBuildSummary is a project plus the latest build data
@@ -31,11 +31,10 @@ type ProjectBuildSummary struct {
 }
 
 // ListWithLatestBuild lists the projects with the latest builds attached.
-func (api Project) ListWithLatestBuild(c *gin.Context) {
-
+func (api Project) ListWithLatestBuild(request *restful.Request, response *restful.Response) {
 	projects, err := api.store.GetProjects()
 	if err != nil {
-		c.JSON(http.StatusNotFound, struct{}{})
+		response.WriteErrorString(http.StatusNotFound, "No Projects found.")
 		return
 	}
 
@@ -48,32 +47,32 @@ func (api Project) ListWithLatestBuild(c *gin.Context) {
 		}
 		res = append(res, pbs)
 	}
-	c.JSON(http.StatusOK, res)
+	response.WriteHeaderAndEntity(http.StatusOK, res)
 }
 
 // Get creates a new gin handler for the GET /project/:id endpoint
-func (api Project) Get(c *gin.Context) {
-	id := c.Params.ByName("id")
+func (api Project) Get(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("id")
 	proj, err := api.store.GetProject(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, struct{}{})
+		response.WriteErrorString(http.StatusNotFound, "No Project found.")
 		return
 	}
-	c.JSON(http.StatusOK, proj)
+	response.WriteHeaderAndEntity(http.StatusOK, proj)
 }
 
 // Builds creates a new gin handler for the GET /project/:id/builds endpoint
-func (api Project) Builds(c *gin.Context) {
-	id := c.Params.ByName("id")
+func (api Project) Builds(request *restful.Request, response *restful.Response) {
+	id := request.PathParameter("id")
 	proj, err := api.store.GetProject(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, struct{}{})
+		response.WriteErrorString(http.StatusNotFound, "No Project found.")
 		return
 	}
 	builds, err := api.store.GetProjectBuilds(proj)
 	if err != nil {
-		c.JSON(http.StatusNotFound, struct{}{})
+		response.WriteErrorString(http.StatusNotFound, "No Project Builds found.")
 		return
 	}
-	c.JSON(http.StatusOK, builds)
+	response.WriteHeaderAndEntity(http.StatusOK, builds)
 }


### PR DESCRIPTION
This PR ports the API framework to a set of libraries that will generate Swagger/OpenAPI spec for consumers of the API. 

This addresses Issues #353 and #354, adding support and making the methods more discoverable.