### PR TITLE
updated fallback script path to look for brigade.js instead of directory

### DIFF
--- a/brigade-worker/prestart.js
+++ b/brigade-worker/prestart.js
@@ -14,7 +14,7 @@ const scripts = [
   "/vcs/brigade.js",
 
   // mounted configmap named in brigade.sh/project.DefaultScriptName
-  "/etc/brigade-default-script",
+  "/etc/brigade-default-script/brigade.js",
 ];
 
 //checked out in repo


### PR DESCRIPTION
Using fallback script in configmap will always fail as prestart.js assumes /etc/brigade-default-script to be a file, but it is a directory (since the configmap is mounted as a volume).
Simple fix: assume the file inside the configmap is named brigade.js (to follow naming from repo script) and update the path to /etc/brigade-default-script/brigade.js

Closes #528 