### PR TITLE
use kebab case for --kashti-namespace

### DIFF
--- a/brig/cmd/brig/commands/proxy.go
+++ b/brig/cmd/brig/commands/proxy.go
@@ -33,7 +33,7 @@ func init() {
 	flags := proxy.PersistentFlags()
 	flags.IntVar(&port, "port", 8081, "local port for the Kashti dashboard")
 	flags.IntVar(&apiPort, "api-port", 7745, "local port for the Brigade API server")
-	flags.StringVarP(&kashtiNamespace, "kashtiNamespace", "", "default", "namespace for Kashti")
+	flags.StringVarP(&kashtiNamespace, "kashti-namespace", "", "default", "namespace for Kashti")
 }
 
 var proxy = &cobra.Command{


### PR DESCRIPTION
This breaks backwards compatibility, but the convention for feature flags has been to use kebab-case, so I figured we should probably bring this in line with the rest of the feature flags.