### PR TITLE
Add docs on brigade.json

### DIFF
--- a/docs/topics/scripting.md
+++ b/docs/topics/scripting.md
@@ -14,6 +14,7 @@ special cluster environment. An environment is composed of the following things:
 - A Brigade server running in your cluster
 - A project in which the script will run
 - (Optionally) A source code repository (e.g. git) that contains data our
+- (Optionally) A [`brigade.json`](workers.md) file that contains additional dependencies that can be used from `brigade.js`
 - (Optionally) Other configuration data, like [secrets](secrets.md)
 
 For the examples in this document, we have created a project with these values:

--- a/docs/topics/workers.md
+++ b/docs/topics/workers.md
@@ -1,17 +1,116 @@
-# Building Custom Workers
+# Adding custom libraries to a Brigade worker
 
 A worker is the component in Brigade that executes a `brigade.js`. Brigade ships
 with a general purpose worker focused on running jobs. This generic worker
 exposes a host of Node.js libraries to `brigade.js` files, as well as the
 `brigadier` Brigade library.
 
-Sometimes, though, it is desirable to add additional libraries -- perhaps even
-custom libraries -- to your workers. This guide walks through the process of
-adding custom libraries.
+Sometimes, though, it is desirable to include additional libraries -- perhaps even
+custom libraries -- to your workers. 
+There are two ways of adding custom dependencies to a Brigade worker:
+
+- by adding a `brigade.json` file in your repository (similar to a `package.json` file) 
+that contains the dependencies and that are specific on every Brigade project
+
+- by creating a custom Docker image for the worker that already contains the dependencies 
+and which will be used for all Brigade projects
+
+This guide explains both processes and describes the cases where each method is most suitable.
 
 **Note:** This area of Brigade is still evolving. If you have ideas for improving
 it, feel free to [file an issue](https://github.com/Azure/brigade/issues) explaining
 your idea.
+
+## Add custom dependencies using a `brigade.json` file
+
+If you need different dependencies for every Brigade project, this can be easily achieved 
+using a `brigade.json` file placed side-by-side the `brigade.js` file. This file contains 
+the dependency name and version, and has the following structure:
+
+```
+{
+    "dependencies": {
+        "is-thirteen": "2.0.0"
+    }
+}
+```
+Before starting to execute the `brigade.js` script, the worker will install the  
+dependencies using `yarn`, adding them to the `node_modules` folder.
+
+Then, in the `brigade.js` file, the new dependency can be used just like any 
+other NodeJS dependency:
+
+```
+const { events } = require("brigadier")
+const is = require("is-thirteen");
+
+events.on("exec", function (e, p) {
+    console.log("is 13 thirteen? " + is(13).thirteen());
+})
+```
+
+Now if we run a build for this project, we see the `is-thirteen` dependency added, 
+as well as the console log resulted from using it:
+
+```
+$ brig run brigade-86959b08a89af5b6b83f0ace6d9030f1fdca7ed8ea0a296e27d72e
+Event created. Waiting for worker pod named "brigade-worker-01cexrvrs08shcev26961cwd6n".
+Started build 01cexrvrs08shcev26961cwd6n as "brigade-worker-01cexrvrs08shcev26961cwd6n"
+installing is-thirteen@2.0.0
+prestart: src/brigade.js written
+[brigade] brigade-worker version: 0.14.0
+[brigade:k8s] Creating PVC named brigade-worker-01cexrvrs08shcev26961cwd6n
+is 13 thirteen? true
+[brigade:app] after: default event handler fired
+[brigade:app] beforeExit(2): destroying storage
+[brigade:k8s] Destroying PVC named brigade-worker-01cexrvrs08shcev26961cwd6n
+```
+
+Notes:
+
+- the dependencies should point the exact version (and not use the tilde ~ and caret ^ to indicate semver compatible versions)
+
+- note the already existing dependencies and dev dependencies for a Brigade worker:
+
+```
+  "dependencies": {
+    "@kubernetes/client-node": "^0.1.3",
+    "child-process-promise": "^2.2.1",
+    "pretty-error": "^2.1.1",
+    "ulid": "^0.2.0"
+  },
+
+  "devDependencies": {
+    "@types/chai": "^4.0.1",
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^8.0.14",
+    "chai": "^4.1.0",
+    "mocha": "5.2.0",
+    "prettier": "^1.9.1",
+    "rimraf": "^2.6.2",
+    "ts-node": "^3.3.0",
+    "typedoc": "^0.8.0",
+    "typescript": "^2.4.2"
+  }
+```
+
+When adding a custom dependency using `brigade.json`, `yarn` will add it side-by-side with the worker's 
+dependencies - this means that the process will fail if a dependency that conflicts with one of the 
+worker's dependency is added. However, already existing dependencies (such as `@kubernetes/client-node`, `ulid` or `chai`) 
+can be used from `brigade.js` without adding them to `brigade.json`. 
+
+However, the only issue is trying to add a different version of an already existing dependency of the worker.
+
+- as the Brigade worker is capable of modifying the state of the cluster, be mindful 
+of any external dependencies added through `brigade.json`
+
+- for now, the only part of `brigade.json` used is the `dependencies` object - it means the rest of the file 
+can be used to pass additional information to `brigade.js`, such as environment data - however, as the `brigade.json` 
+file is passed in the source control repository, information passed there will be available to anyone with access to the repository.
+
+- all dependencies added in `brigade.json` are dynamically installed on every Brigade build - this means if the dependencies added 
+are large, and the build frequency is high for a particular project, it might make sense to make a pre-built Docker image that 
+already contains the dependencies, as described in the sections below.
 
 ## Workers and Docker Images
 

--- a/docs/topics/workers.md
+++ b/docs/topics/workers.md
@@ -70,32 +70,8 @@ Notes:
 
 - the dependencies should point the exact version (and not use the tilde ~ and caret ^ to indicate semver compatible versions)
 
-- note the already existing dependencies and dev dependencies for a Brigade worker:
-
-```
-  "dependencies": {
-    "@kubernetes/client-node": "^0.1.3",
-    "child-process-promise": "^2.2.1",
-    "pretty-error": "^2.1.1",
-    "ulid": "^0.2.0"
-  },
-
-  "devDependencies": {
-    "@types/chai": "^4.0.1",
-    "@types/mocha": "^2.2.41",
-    "@types/node": "^8.0.14",
-    "chai": "^4.1.0",
-    "mocha": "5.2.0",
-    "prettier": "^1.9.1",
-    "rimraf": "^2.6.2",
-    "ts-node": "^3.3.0",
-    "typedoc": "^0.8.0",
-    "typescript": "^2.4.2"
-  }
-```
-
-When adding a custom dependency using `brigade.json`, `yarn` will add it side-by-side with the worker's 
-dependencies - this means that the process will fail if a dependency that conflicts with one of the 
+- when adding a custom dependency using `brigade.json`, `yarn` will add it side-by-side with [the worker's 
+dependencies](../../brigade-worker/package.json) - this means that the process will fail if a dependency that conflicts with one of the 
 worker's dependency is added. However, already existing dependencies (such as `@kubernetes/client-node`, `ulid` or `chai`) 
 can be used from `brigade.js` without adding them to `brigade.json`. 
 


### PR DESCRIPTION
This PR adds documentation around using a `brigade.json` file to add custom dependencies to a Brigade worker.

closes #497