### PR TITLE
Make service account creation conditional

### DIFF
--- a/charts/brigade/Chart.yaml
+++ b/charts/brigade/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Brigade provides event-driven scripting of Kubernetes pipelines.
 name: brigade
-version: 0.15.0
+version: 0.15.1
 # Note that we use appVersion to get images, so make sure this is correct.
 appVersion: v0.15.0

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -34,6 +34,6 @@ spec:
           - name: BRIGADE_WORKER_PULL_POLICY
             value: {{ default "IfNotPresent" .Values.worker.pullPolicy }}
           - name: BRIGADE_WORKER_SERVICE_ACCOUNT
-            value: {{ default "brigade-worker" .Values.worker.serviceAccount }}
+            value: {{ default "brigade-worker" .Values.worker.serviceAccount.name }}
       {{ if .Values.privateRegistry }}imagePullSecrets:
         - name: {{.Values.privateRegistry}}{{ end }}

--- a/charts/brigade/templates/vacuum-cronjob.yaml
+++ b/charts/brigade/templates/vacuum-cronjob.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.vacuum.enabled }}{{ $fullname := include "brigade.vacuum.fullname" .}}
+{{ $serviceAccount := default "brigade-vacuum" .Values.vacuum.serviceAccount.name }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -21,7 +22,7 @@ spec:
             app: {{ template "brigade.fullname" . }}
             role: vacuum
         spec:
-          serviceAccountName: {{ $fullname }}
+          serviceAccountName: {{ $serviceAccount }}
           containers:
           - name: {{ .Chart.Name }}-vacuum
             image: "{{ .Values.vacuum.registry }}/{{ .Values.vacuum.name }}:{{ default .Chart.AppVersion .Values.vacuum.tag }}"

--- a/charts/brigade/templates/vacuum-role.yaml
+++ b/charts/brigade/templates/vacuum-role.yaml
@@ -17,7 +17,7 @@ metadata:
 kind: Role
 apiVersion: {{ template "brigade.rbac.version" }}
 metadata:
-  name: {{ $serviceAccount }}
+  name: {{ $fname }}
   labels:
     app: {{ template "brigade.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/brigade/templates/vacuum-role.yaml
+++ b/charts/brigade/templates/vacuum-role.yaml
@@ -1,10 +1,12 @@
 {{ if .Values.vacuum.enabled }}
 {{ $fname := include "brigade.vacuum.fullname" . }}
+{{ $serviceAccount := default "brigade-vacuum" .Values.vacuum.serviceAccount.name }}
+{{ if .Values.vacuum.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app: {{ template "brigade.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -15,7 +17,7 @@ metadata:
 kind: Role
 apiVersion: {{ template "brigade.rbac.version" }}
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app: {{ template "brigade.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -40,10 +42,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}
   apiGroup: rbac.authorization.k8s.io
 {{ end }}{{/* end if rbac enabled */}}
+{{ end }}{{/* end if create service account */}}
 {{ end }}{{/* end if vacuum enabled */}}

--- a/charts/brigade/templates/worker-role.yaml
+++ b/charts/brigade/templates/worker-role.yaml
@@ -1,5 +1,6 @@
 {{ $fname := include "brigade.worker.fullname" . }}
-{{ $serviceAccount := default "brigade-worker" .Values.worker.serviceAccount }}
+{{ $serviceAccount := default "brigade-worker" .Values.worker.serviceAccount.name }}
+{{ if .Values.worker.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -45,4 +46,5 @@ roleRef:
   kind: Role
   name: {{ $fname }}
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -77,7 +77,9 @@ api:
 worker:
   registry: deis
   name: brigade-worker
-  serviceAccount: brigade-worker
+  serviceAccount: 
+    create: true
+    name: brigade-worker
   #tag:
   #pullPolicy: IfNotPresent
 
@@ -148,6 +150,9 @@ vacuum:
   #
   # If both age and maxBuilds are provided, age is applied first, then maxBuilds.
   maxBuilds: 0
+  serviceAccount:
+    create: true
+    name: 
 
 # The service is for the Brigade gateway. If you do not want to have Brigade
 # listening for incomming GitHub requests, disable this.


### PR DESCRIPTION
In some situations a user may want to create the service accounts outside
of the helm process.

Currently, this isn't possible with brigade as brigade will always attempt
to create the service accounts.

This update introduces new values to conditionally enable/disable the
creation of the service accounts for worker nodes and the vacuum.

Signed-off-by: Ian Duffy <ian@ianduffy.ie>