### PR TITLE
use select{} instead of for{}

### DIFF
--- a/brig/cmd/brig/commands/dashboard.go
+++ b/brig/cmd/brig/commands/dashboard.go
@@ -67,7 +67,7 @@ var dashboard = &cobra.Command{
 		}
 
 		// block until the user sends a CTRL+C
-		for {
+		select {
 		}
 	},
 }


### PR DESCRIPTION
for{} causes the main loop to constantly claim clock cycles, whereas
select{} causes the goroutine to block and puts it to sleep, which is
the intention.