### PR TITLE
fix(style): change import formatting to satisfy goimport fails

### DIFF
--- a/brig/cmd/brig/commands/dashboard.go
+++ b/brig/cmd/brig/commands/dashboard.go
@@ -7,11 +7,13 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Azure/brigade/pkg/portforwarder"
 	"github.com/bacongobbler/browser"
 	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/Azure/brigade/pkg/portforwarder"
 )
 
 const (


### PR DESCRIPTION
Fixes this:

```
gometalinter --config ./gometalinter.json ./...
brig/cmd/brig/commands/dashboard.go:1::warning: file is not goimported (goimports)
make: *** [test-style] Error 1
```