### PR TITLE
fix(brigade.js): shorten the error message

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -64,7 +64,7 @@ function build(e, project) {
     }
     return Promise.resolve(runRelease)
   }).catch(err => {
-    return ghNotify("failure", `failed build ${ e.buildID } ${ err.toString() }`, e, project).run()
+    return ghNotify("failure", `failed build ${ e.buildID }`, e, project).run()
   });
 }
 


### PR DESCRIPTION
GitHub was failing to update builds on error because the error message
was too long.

Closes #555