### PR TITLE
feat(brig): list builds by project

### DIFF
--- a/brig/cmd/brig/commands/build_list.go
+++ b/brig/cmd/brig/commands/build_list.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/duration"
 
+	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/storage/kube"
 )
 
@@ -23,24 +24,42 @@ func init() {
 }
 
 var buildList = &cobra.Command{
-	Use:   "list",
+	Use:   "list [project]",
 	Short: "list builds",
 	Long:  buildListUsage,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return listBuilds(cmd.OutOrStdout())
+		proj := ""
+		if len(args) > 0 {
+			proj = args[0]
+		}
+		return listBuilds(cmd.OutOrStdout(), proj)
 	},
 }
 
-func listBuilds(out io.Writer) error {
+func listBuilds(out io.Writer, project string) error {
 	c, err := kubeClient()
 	if err != nil {
 		return err
 	}
 
 	store := kube.New(c, globalNamespace)
-	bs, err := store.GetBuilds()
-	if err != nil {
-		return err
+
+	var bs []*brigade.Build
+	if project == "" {
+		bs, err = store.GetBuilds()
+		if err != nil {
+			return err
+		}
+	} else {
+		proj, err := store.GetProject(project)
+		if err != nil {
+			return err
+		}
+
+		bs, err = store.GetProjectBuilds(proj)
+		if err != nil {
+			return err
+		}
 	}
 
 	table := uitable.New()

--- a/brig/cmd/brig/commands/project_get.go
+++ b/brig/cmd/brig/commands/project_get.go
@@ -1,12 +1,12 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/Azure/brigade/pkg/storage/kube"
 )
@@ -46,7 +46,12 @@ func getProject(out io.Writer, name string) error {
 		return err
 	}
 
-	bytes, err := yaml.Marshal(p)
+	s, err := kube.SecretFromProject(p)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This add `brig build list PROJECT_ID`.

It also modifies `brig project get` to return a Secret, which is the
default format we work with, rather than a one-off representation.