### PR TITLE
feat(brig): return JSON from 'brig project get'

### DIFF
--- a/brig/cmd/brig/commands/project_get.go
+++ b/brig/cmd/brig/commands/project_get.go
@@ -46,12 +46,12 @@ func getProject(out io.Writer, name string) error {
 		return err
 	}
 
-	s, err := kube.SecretFromProject(p)
+	sec, err := kube.SecretFromProject(p)
 	if err != nil {
 		return err
 	}
 
-	bytes, err := json.MarshalIndent(s, "", "  ")
+	bytes, err := json.MarshalIndent(sec, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This returns a formatted JSON secret instead of a dump of an internal
struct.

See #541