### PR TITLE
fix(vacuum): set default max builds to -1

### DIFF
--- a/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
@@ -52,14 +52,14 @@ var (
 	globalNamespace  = ""
 	globalAge        = ""
 	globalVerbose    = false
-	globalMaxBuilds  = -1
+	globalMaxBuilds  = vacuum.NoMaxBuilds
 )
 
 func init() {
 	f := Root.PersistentFlags()
 	f.StringVarP(&globalNamespace, "namespace", "n", "", "The Kubernetes namespace for Brigade")
 	f.StringVarP(&globalAge, "age", "a", "", "Age as a fuzzy date ('48h' for hours, '20m' for minutes, '2000s' for seconds)")
-	f.IntVarP(&globalMaxBuilds, "max-builds", "m", -1, "Maxinum number of builds to keep")
+	f.IntVarP(&globalMaxBuilds, "max-builds", "m", vacuum.NoMaxBuilds, "Maxinum number of builds to keep")
 	f.BoolVarP(&globalVerbose, "verbose", "v", false, "Turn on verbose output")
 	f.StringVar(&globalKubeConfig, "kubeconfig", "", "The path to a KUBECONFIG file, overrides $KUBECONFIG.")
 }
@@ -75,7 +75,7 @@ var Root = &cobra.Command{
 		if a == "" && mb == 0 {
 			return errors.New("one of --age or --max-builds must be greater than zero")
 		}
-		var age = time.Time{}
+		var age = vacuum.NoMaxAge
 		if a != "" {
 			dur, err := time.ParseDuration(a)
 			if err != nil {

--- a/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
@@ -59,7 +59,7 @@ func init() {
 	f := Root.PersistentFlags()
 	f.StringVarP(&globalNamespace, "namespace", "n", "", "The Kubernetes namespace for Brigade")
 	f.StringVarP(&globalAge, "age", "a", "", "Age as a fuzzy date ('48h' for hours, '20m' for minutes, '2000s' for seconds)")
-	f.IntVarP(&globalMaxBuilds, "max-builds", "m", 0, "Maxinum number of builds to keep")
+	f.IntVarP(&globalMaxBuilds, "max-builds", "m", -1, "Maxinum number of builds to keep")
 	f.BoolVarP(&globalVerbose, "verbose", "v", false, "Turn on verbose output")
 	f.StringVar(&globalKubeConfig, "kubeconfig", "", "The path to a KUBECONFIG file, overrides $KUBECONFIG.")
 }
@@ -88,7 +88,7 @@ var Root = &cobra.Command{
 			return err
 		}
 		if globalVerbose {
-			fmt.Fprintf(os.Stderr, "Max Age: %s\nMax Builds: %d\n", age, globalMaxBuilds)
+			fmt.Fprintf(os.Stderr, "Max Age: %s\nMax Builds: %d\n", age, mb)
 		}
 		count, err := vacuum.New(age, mb, c, ns()).Run()
 		fmt.Fprintf(os.Stdout, "Deleted %d\n", count)

--- a/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
@@ -78,22 +78,24 @@ func (v *Vacuum) Run() (int, error) {
 		return deleted, err
 	}
 	l := len(secrets.Items)
-	if l > v.max {
-		sort.Sort(ByCreation(secrets.Items))
-		for i := v.max; i < l; i++ {
-			// Delete secret and builds
-			s := secrets.Items[i]
-			bid, ok := s.ObjectMeta.Labels["build"]
-			if !ok {
-				log.Printf("Build %q has no build ID. Skipping.\n", s.Name)
-				continue
-			}
-			if err := v.deleteBuild(bid); err != nil {
-				log.Printf("Failed to delete build %s: %s (max)\n", bid, err)
-				continue
-			}
-			deleted++
+	if l <= v.max {
+		log.Printf("Skipping vacuum. %d is ≤ max %d", l, v.max)
+		return deleted, nil
+	}
+	sort.Sort(ByCreation(secrets.Items))
+	for i := v.max; i < l; i++ {
+		// Delete secret and builds
+		s := secrets.Items[i]
+		bid, ok := s.ObjectMeta.Labels["build"]
+		if !ok {
+			log.Printf("Build %q has no build ID. Skipping.\n", s.Name)
+			continue
 		}
+		if err := v.deleteBuild(bid); err != nil {
+			log.Printf("Failed to delete build %s: %s (max)\n", bid, err)
+			continue
+		}
+		deleted++
 	}
 
 	return deleted, nil

--- a/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum.go
@@ -11,6 +11,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// NoMaxBuilds indicates that there is no maximum number of builds.
+const NoMaxBuilds = -1
+
+// NoMaxAge indicates that there is no maximum age.
+var NoMaxAge = time.Time{}
+
 const (
 	buildFilter = "component = build, heritage = brigade"
 	jobFilter   = "component in (build, job), heritage = brigade, build = %s"
@@ -68,7 +74,7 @@ func (v *Vacuum) Run() (int, error) {
 	}
 
 	// If no max, return now.
-	if v.max == 0 {
+	if v.max == NoMaxBuilds {
 		return deleted, nil
 	}
 

--- a/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum_test.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/vacuum/vacuum_test.go
@@ -28,7 +28,7 @@ func TestRun_Age(t *testing.T) {
 		t.Fatalf("expected 3 pods, got %d", len(pods.Items))
 	}
 
-	num, err := New(time.Now(), 0, client, v1.NamespaceDefault).Run()
+	num, err := New(time.Now(), NoMaxBuilds, client, v1.NamespaceDefault).Run()
 	if err != nil {
 		t.Errorf("I blame fakeclient: %s", err)
 	}


### PR DESCRIPTION
There was a discrepancy between whether the default value for max builds was -1 or 0. As a result, `VACUUM_MAX_BUILDS` was always overridden by the default `-m` value.

Closes #576 