### PR TITLE
feat(brigade.js): Add link to Kashti

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -126,7 +126,8 @@ function ghNotify(state, msg, e, project) {
     GH_DESCRIPTION: msg,
     GH_CONTEXT: "brigade",
     GH_TOKEN: project.secrets.ghToken,
-    GH_COMMIT: e.revision.commit
+    GH_COMMIT: e.revision.commit,
+    GH_TARGET_URL: `https://azure.github.io/kashti/builds/${ e.buildID }`,
   }
   return gh
 }


### PR DESCRIPTION
Adds a link to the official Kashti to show the status of the build.