### PR TITLE
Fixed pip install link

### DIFF
--- a/docs/intro/tutorial01.md
+++ b/docs/intro/tutorial01.md
@@ -29,7 +29,7 @@ You can tell pip is installed and which version by running the following command
 $ pip --version
 ```
 
-If you see "command not found", see [how to install pip][install-pip] for advice on how to install pip.
+If you see "command not found", see [how to install pip](https://pip.pypa.io/en/stable/installing/) for advice on how to install pip.
 
 If you're having trouble going through this tutorial, please post an issue to [Azure/brigade][github] to chat with other Brigade users who might be able to help.
 


### PR DESCRIPTION
Sent it to the [official pip docs](https://pip.pypa.io/en/stable/installing/) instead.