### PR TITLE
fix(brigade, worker): fixing a few minor nits

### DIFF
--- a/brigade-worker/src/events.ts
+++ b/brigade-worker/src/events.ts
@@ -241,4 +241,8 @@ export class EventRegistry extends EventEmitter {
   public fire(e: BrigadeEvent, proj: Project) {
     this.emit(e.type, e, proj);
   }
+
+  public on(eventName: string | symbol, cb: ((...args: any[]) => void)): this {
+    return super.on(eventName, cb)
+  }
 }

--- a/brigade.js
+++ b/brigade.js
@@ -107,11 +107,12 @@ function releaseBrig(e, p, tag) {
 
   // Upload for each target that we support
   for (const f of ["linux-amd64", "windows-amd64", "darwin-amd64"]) {
-    var name = binName + "-"+f
+    var name = binName + "-" + f;
+    var outname = name;
     if (f == "windows-amd64") {
-      name += ".exe"
+      outname += ".exe"
     }
-    cx.tasks.push(`github-release upload -f ./bin/${name} -n ${name} -t ${tag}`)  
+    cx.tasks.push(`github-release upload -f ./bin/${name} -n ${outname} -t ${tag}`)  
   }
   console.log(cx.tasks);
   console.log(`releases at https://github.com/${p.repo.name}/releases/tag/${tag}`);


### PR DESCRIPTION
Newer typescripts (3+) complain if the `on` method isn't overridden.

Also, the windows binary was not correctly given the exe extension,
which is causing failed brig prod builds.