### PR TITLE
feat(brig): add -f flag to rerun command

### DIFF
--- a/brig/cmd/brig/commands/rerun.go
+++ b/brig/cmd/brig/commands/rerun.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"errors"
+	"io/ioutil"
 
 	"github.com/spf13/cobra"
 )
@@ -11,12 +12,18 @@ const rerunUsage = `Request that Brigade re-run a build.
 This will clone an old event, assign it a new build ID, and resubmit it. The build
 must still be accessible. Once a build is vacuumed, it can no longer be re-run.
 
+Using the '-f' flag will cause brig to resend the old payload, but override the old
+script with the provided one.
 `
 
-var rerunLogLevel string
+var (
+	rerunLogLevel string
+	rerunFile     string
+)
 
 func init() {
 	rerun.Flags().StringVarP(&rerunLogLevel, "level", "l", "log", "Specified log level: log, info, warn, error")
+	rerun.Flags().StringVarP(&rerunFile, "file", "f", "", "Override the JS file from the last build")
 	Root.AddCommand(rerun)
 }
 
@@ -38,6 +45,14 @@ var rerun = &cobra.Command{
 		build, err := a.getBuild(bid)
 		if err != nil {
 			return err
+		}
+
+		if rerunFile != "" {
+			data, err := ioutil.ReadFile(rerunFile)
+			if err != nil {
+				return err
+			}
+			build.Script = data
 		}
 
 		// Override a few things


### PR DESCRIPTION
This provides a way to rerun a payload, but replace the script file.
This ought to greatly improve the debugging experience when a script
fails.