### PR TITLE
fix(chart): set max builds to -1 by default

### DIFF
--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -149,7 +149,7 @@ vacuum:
   # 0 means no limit is imposed.
   #
   # If both age and maxBuilds are provided, age is applied first, then maxBuilds.
-  maxBuilds: 0
+  maxBuilds: -1
   serviceAccount:
     create: true
     name: 

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -146,7 +146,7 @@ vacuum:
   age: "720h"
   # maxBuilds tells the vacuum what the absolute maximum number of builds may be stored
   # at a time. Where possible, we recommend using age rather than builds.
-  # 0 means no limit is imposed.
+  # -1 means no limit is imposed.
   #
   # If both age and maxBuilds are provided, age is applied first, then maxBuilds.
   maxBuilds: -1


### PR DESCRIPTION
A recent fix standardized on maxBuilds=0 meaning no builds are kept. But the chart sets maxBuilds=0 by default. This changes the default to -1.