### PR TITLE
Re-use globalNamespace flag for brig dashboard

### DIFF
--- a/brig/cmd/brig/commands/dashboard.go
+++ b/brig/cmd/brig/commands/dashboard.go
@@ -33,7 +33,6 @@ func init() {
 
 	flags := dashboard.PersistentFlags()
 	flags.IntVar(&port, "port", 8081, "local port for the Kashti dashboard")
-	flags.StringVar(&kashtiNamespace, "kashti-namespace", "default", "namespace for Kashti")
 	flags.BoolVar(&openDashboard, "open-dashboard", true, "open the dashboard in the browser")
 }
 
@@ -82,7 +81,7 @@ func startProxy(kashtiPort int) (*portforwarder.Tunnel, error) {
 	}
 
 	kashtiSelector := labels.Set{"app": "kashti"}.AsSelector()
-	tunnel, err := portforwarder.New(c, config, kashtiNamespace, kashtiSelector, remotePort, port)
+	tunnel, err := portforwarder.New(c, config, globalNamespace, kashtiSelector, remotePort, port)
 	if err != nil {
 		return nil, fmt.Errorf("cannot start port forward for kashti: %v", err)
 	}


### PR DESCRIPTION
This PR removes the `kashti-namespace` provided for `brig dashboard` and re-uses the global `--namespace` flag for `brig` - that is because `brig dashboard` only creates a tunnel to the Kashti pod and doesn't need to forward the port of the Brigade API.

While this removes the confusion brought by having two flags for the namespace, it re-uses the global namespace flag that in the rest of the CLI is used to indicate the namespace where Brigade is deployed, to indicate the namespace where Kashti is deployed.

Considering that we want to [include Kashti in the Brigade chart](https://github.com/Azure/brigade/issues/504#issue-331321180), having the two deployed in separate namespaces might disappear in the past.


cc @mattfarina @technosophos 

closes #598  