### PR TITLE
fix(brig): generate shared secret when none exists

### DIFF
--- a/brig/cmd/brig/commands/project_create.go
+++ b/brig/cmd/brig/commands/project_create.go
@@ -276,9 +276,9 @@ func projectCreatePrompts(p *brigade.Project) error {
 
 	}
 
-	if p.SharedSecret != "" {
-		fmt.Println("Auto-generating a Shared Secret...")
+	if p.SharedSecret == "" {
 		p.SharedSecret, _ = goutils.RandomAlphaNumeric(24)
+		fmt.Printf("Auto-generated a Shared Secret: %q\n", p.SharedSecret)
 	}
 
 	configureGitHub := false


### PR DESCRIPTION
This fixes a bug in the shared secret generation logic.

Closes #574
Closes #597