### PR TITLE
fix(git-sidecar): remove hard reset in sidecar

### DIFF
--- a/git-sidecar/rootfs/clone.sh
+++ b/git-sidecar/rootfs/clone.sh
@@ -26,9 +26,6 @@ cd "${BRIGADE_WORKSPACE}"
 
 git fetch -q --force --update-head-ok "${BRIGADE_REMOTE_URL}" "${refspec}"
 
-# reset to $BRIGADE_COMMIT_ID or FETCH_HEAD
-git reset -q --hard "${BRIGADE_COMMIT_ID:-FETCH_HEAD}"
-
 git checkout -q --force "${BRIGADE_COMMIT_REF}"
 
 if [ "${BRIGADE_SUBMODULES:=}" = "true" ]; then


### PR DESCRIPTION
fixes: #609

When using github's squash and merge strategy the HEAD sha is no longer
fetched using the pull reference.  This removes the hard reset which
isn't needed in our case because we clone a new repo every build.