### PR TITLE
fix BuildStorage in brigade worker to prevent crash when project load fails

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -81,7 +81,7 @@ export class BuildStorage {
   proj: Project;
   name: string;
   build: string;
-  logger: ContextLogger;
+  logger: ContextLogger = new ContextLogger("k8s");
 
   /**
    * create initializes a new PVC for storing data.
@@ -94,7 +94,7 @@ export class BuildStorage {
     this.proj = project;
     this.name = e.workerID.toLowerCase();
     this.build = e.buildID;
-    this.logger = new ContextLogger("k8s", e.logLevel);
+    this.logger.logLevel = e.logLevel;
 
     let pvc = this.buildPVC(size);
     this.logger.log(`Creating PVC named ${this.name}`);
@@ -113,6 +113,11 @@ export class BuildStorage {
    * destroy deletes the PVC.
    */
   public destroy(): Promise<boolean> {
+    if(!this.proj && !this.name) {
+      this.logger.log('Build storage not exists');
+      return Promise.resolve(false);
+    }
+
     this.logger.log(`Destroying PVC named ${this.name}`);
     let opts = new kubernetes.V1DeleteOptions();
     return Promise.resolve<boolean>(


### PR DESCRIPTION
Build storage class initializes its variables in BuildStorage.create() after loading project but when project does not exists or there is error in loading project, build storage is not created so variables are left uninitialized e.g (logger). Later when error is handled in app.ts , it tries to destroy build storage. In this case the storage wasn't initialized in the first place which terminates worker in the middle of exception. 

![capture](https://user-images.githubusercontent.com/10983181/44989870-bd4b5f00-afa8-11e8-81a0-ae930d1ae4c7.PNG)
