### PR TITLE
feat(brig): `brig run` as a go library

### DIFF
--- a/brig/cmd/brig/commands/rerun.go
+++ b/brig/cmd/brig/commands/rerun.go
@@ -4,7 +4,11 @@ import (
 	"errors"
 	"io/ioutil"
 
+	"os"
+
 	"github.com/spf13/cobra"
+
+	"github.com/Azure/brigade/pkg/script"
 )
 
 const rerunUsage = `Request that Brigade re-run a build.
@@ -37,12 +41,17 @@ var rerun = &cobra.Command{
 		}
 		bid := args[0]
 
-		a, err := newScriptRunner()
+		kc, err := kubeClient()
 		if err != nil {
 			return err
 		}
 
-		build, err := a.getBuild(bid)
+		a, err := script.NewDelegatedRunner(kc, os.Stdout, globalNamespace, runNoProgress, runBackground, globalVerbose)
+		if err != nil {
+			return err
+		}
+
+		build, err := a.GetBuild(bid)
 		if err != nil {
 			return err
 		}
@@ -60,6 +69,6 @@ var rerun = &cobra.Command{
 		build.LogLevel = rerunLogLevel
 		build.Worker = nil
 
-		return a.sendBuild(build)
+		return a.SendBuild(build)
 	},
 }

--- a/brig/cmd/brig/commands/rerun.go
+++ b/brig/cmd/brig/commands/rerun.go
@@ -46,10 +46,13 @@ var rerun = &cobra.Command{
 			return err
 		}
 
-		a, err := script.NewDelegatedRunner(kc, os.Stdout, globalNamespace, runNoProgress, runBackground, globalVerbose)
+		a, err := script.NewDelegatedRunner(kc, os.Stdout, globalNamespace)
 		if err != nil {
 			return err
 		}
+		a.NoProgress = runNoProgress
+		a.Background = runBackground
+		a.Verbose = globalVerbose
 
 		build, err := a.GetBuild(bid)
 		if err != nil {

--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -101,10 +101,13 @@ var run = &cobra.Command{
 			return err
 		}
 
-		runner, err := script.NewDelegatedRunner(kc, destination, globalNamespace, runNoProgress, runBackground, globalVerbose)
+		runner, err := script.NewDelegatedRunner(kc, destination, globalNamespace)
 		if err != nil {
 			return err
 		}
+		runner.NoProgress = runNoProgress
+		runner.Background = runBackground
+		runner.Verbose = globalVerbose
 
 		return runner.SendScript(proj, scr, runEvent, runCommitish, runRef, payload, runLogLevel)
 	},

--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -1,27 +1,15 @@
 package commands
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-	"regexp"
-	"strings"
-	"time"
 
-	"github.com/Masterminds/kitt/progress"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
-	"github.com/Azure/brigade/pkg/brigade"
 	"github.com/Azure/brigade/pkg/decolorizer"
-	"github.com/Azure/brigade/pkg/storage"
-	"github.com/Azure/brigade/pkg/storage/kube"
+	"github.com/Azure/brigade/pkg/script"
 )
 
 var (
@@ -36,11 +24,8 @@ var (
 	runBackground bool
 )
 
-var logPattern = regexp.MustCompile(`\[brigade:k8s\]\s[a-zA-Z0-9-]+/[a-zA-Z0-9-]+ phase \w+`)
-
 const (
-	defaultRef  = "master"
-	waitTimeout = 5 * time.Minute
+	defaultRef = "master"
 )
 
 const runUsage = `Send a Brigade JS file to the server.
@@ -88,213 +73,39 @@ var run = &cobra.Command{
 		}
 		proj := args[0]
 
-		var script []byte
+		var scr []byte
 		if len(runFile) > 0 {
 			var err error
-			if script, err = ioutil.ReadFile(runFile); err != nil {
+			if scr, err = ioutil.ReadFile(runFile); err != nil {
 				return err
 			}
 		}
 
-		a, err := newScriptRunner()
+		var payload []byte
+		if len(runPayload) > 0 {
+			var err error
+			if payload, err = ioutil.ReadFile(runPayload); err != nil {
+				return err
+			}
+		}
+
+		var destination io.Writer = os.Stdout
+		if runNoColor {
+			// Pipe the data through a Writer that strips the color codes and then
+			// sends the resulting data to the underlying writer.
+			destination = decolorizer.New(destination)
+		}
+
+		kc, err := kubeClient()
 		if err != nil {
 			return err
 		}
 
-		return a.send(proj, script)
-	},
-}
-
-func newScriptRunner() (*scriptRunner, error) {
-	c, err := kubeClient()
-	if err != nil {
-		return nil, err
-	}
-
-	app := &scriptRunner{
-		store:      kube.New(c, globalNamespace),
-		kc:         c,
-		event:      runEvent,
-		commit:     runCommitish,
-		ref:        runRef,
-		logLevel:   strings.ToUpper(runLogLevel),
-		background: runBackground,
-	}
-	if len(runPayload) > 0 {
-		data, err := ioutil.ReadFile(runPayload)
+		runner, err := script.NewDelegatedRunner(kc, destination, globalNamespace, runNoProgress, runBackground, globalVerbose)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		app.payload = data
-	}
-	return app, nil
-}
 
-type scriptRunner struct {
-	store      storage.Store
-	kc         kubernetes.Interface
-	payload    []byte
-	event      string
-	commit     string
-	ref        string
-	logLevel   string
-	background bool
-}
-
-func (a *scriptRunner) sendBuild(b *brigade.Build) error {
-	if err := a.store.CreateBuild(b); err != nil {
-		return err
-	}
-
-	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
-
-	if a.background {
-		fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
-		return nil
-	}
-	fmt.Printf("Event created. Waiting for worker pod named %q.\n", podName)
-
-	if err := a.waitForWorker(b.ID); err != nil {
-		return err
-	}
-
-	var destination io.Writer = os.Stdout
-	if runNoColor {
-		// Pipe the data through a Writer that strips the color codes and then
-		// sends the resulting data to the underlying writer.
-		destination = decolorizer.New(destination)
-	}
-
-	fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
-	return a.podLog(podName, destination)
-}
-
-func (a *scriptRunner) send(projectName string, data []byte) error {
-
-	projectID := brigade.ProjectID(projectName)
-	if _, err := a.store.GetProject(projectID); err != nil {
-		return fmt.Errorf("could not find the project %q: %s", projectName, err)
-	}
-
-	b := &brigade.Build{
-		ProjectID: projectID,
-		Type:      a.event,
-		Provider:  "brigade-cli",
-		Revision: &brigade.Revision{
-			Commit: a.commit,
-			Ref:    a.ref,
-		},
-		Payload:  a.payload,
-		Script:   data,
-		LogLevel: a.logLevel,
-	}
-	return a.sendBuild(b)
-}
-
-// waitForWorker waits until the worker has started.
-func (a *scriptRunner) waitForWorker(buildID string) error {
-	opts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("heritage=brigade,component=build,build=%s", buildID),
-	}
-	req, err := a.kc.CoreV1().Pods(globalNamespace).Watch(opts)
-	if err != nil {
-		return err
-	}
-	res := req.ResultChan()
-
-	// Now we block until the Pod is ready
-	timeout := time.After(2 * time.Minute)
-	for {
-		select {
-		case e := <-res:
-			if globalVerbose {
-				d, _ := json.MarshalIndent(e.Object, "", "  ")
-				fmt.Printf("Event: %s\n %s\n", e.Type, d)
-			}
-			// If the pod is added or modified, check the phase and see if it is
-			// running or complete.
-			switch e.Type {
-			case "DELETED":
-				// This happens if a user directly kills the pod with kubectl.
-				return fmt.Errorf("worker %s was just deleted unexpectedly", buildID)
-			case "ADDED", "MODIFIED":
-				pod := e.Object.(*v1.Pod)
-				switch pod.Status.Phase {
-				// Unhandled cases are Unknown and Pending, both of which should
-				// cause the loop to spin.
-				case "Running", "Succeeded":
-					req.Stop()
-					return nil
-				case "Failed":
-					req.Stop()
-					return fmt.Errorf("pod failed to schedule: %s", pod.Status.Reason)
-				}
-			}
-		case <-timeout:
-			req.Stop()
-			return fmt.Errorf("timeout waiting for build %s to start", buildID)
-		}
-	}
-}
-
-func (a *scriptRunner) podLog(name string, w io.Writer) error {
-	req := a.kc.CoreV1().Pods(globalNamespace).GetLogs(name, &v1.PodLogOptions{Follow: true})
-
-	readCloser, err := req.Timeout(waitTimeout).Stream()
-	if err != nil {
-		return err
-	}
-	defer readCloser.Close()
-
-	if !runNoProgress {
-		progressLogs(w, readCloser)
-	}
-
-	_, err = io.Copy(w, readCloser)
-	return err
-}
-
-func (a *scriptRunner) getBuild(bid string) (*brigade.Build, error) {
-	return a.store.GetBuild(bid)
-}
-
-func progressLogs(w io.Writer, r io.Reader) {
-	scanner := bufio.NewScanner(r)
-	last := []byte{}
-	p := &progress.Indicator{
-		Interval: 200 * time.Millisecond,
-		Writer:   w,
-		Frames: []string{
-			"....",
-			"=...",
-			".=..",
-			"..=.",
-			"...=",
-			"....",
-			"...=",
-			"..=.",
-			".=..",
-			"=...",
-		},
-	}
-	started := false
-	for scanner.Scan() {
-		raw := scanner.Bytes()
-		if string(raw) == string(last) && logPattern.Match(raw) {
-			if started {
-				continue
-			}
-			name := strings.Fields(string(raw))
-			p.Start(name[len(name)-1])
-			started = true
-		} else {
-			if started {
-				p.Done("done")
-				started = false
-			}
-			w.Write(raw)
-			w.Write([]byte{'\n'})
-		}
-		last = raw
-	}
+		return runner.SendScript(proj, scr, runEvent, runCommitish, runRef, payload, runLogLevel)
+	},
 }

--- a/pkg/script/delegated_runner.go
+++ b/pkg/script/delegated_runner.go
@@ -1,0 +1,203 @@
+package script
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/kitt/progress"
+
+	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/Azure/brigade/pkg/storage"
+	"github.com/Azure/brigade/pkg/storage/kube"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var logPattern = regexp.MustCompile(`\[brigade:k8s\]\s[a-zA-Z0-9-]+/[a-zA-Z0-9-]+ phase \w+`)
+
+const (
+	waitTimeout = 5 * time.Minute
+)
+
+func NewDelegatedRunner(c *kubernetes.Clientset, logDest io.Writer, namespace string, noProgress, background, verbose bool) (*scriptRunner, error) {
+	app := &scriptRunner{
+		store:          kube.New(c, namespace),
+		kc:             c,
+		namespace:      namespace,
+		logDestination: logDest,
+		noProgress:     noProgress,
+		background:     background,
+		verbose:        verbose,
+	}
+	return app, nil
+}
+
+type scriptRunner struct {
+	store     storage.Store
+	kc        kubernetes.Interface
+	namespace string
+
+	logDestination io.Writer
+
+	noProgress bool
+	background bool
+	verbose    bool
+}
+
+func (a *scriptRunner) SendBuild(b *brigade.Build) error {
+	if err := a.store.CreateBuild(b); err != nil {
+		return err
+	}
+
+	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
+
+	if a.background {
+		fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
+		return nil
+	}
+	fmt.Printf("Event created. Waiting for worker pod named %q.\n", podName)
+
+	if err := a.waitForWorker(b.ID); err != nil {
+		return err
+	}
+
+	fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
+	return a.podLog(podName, a.logDestination)
+}
+
+func (a *scriptRunner) SendScript(projectName string, data []byte, event, commitish, ref string, payload []byte, logLevel string) error {
+
+	projectID := brigade.ProjectID(projectName)
+	if _, err := a.store.GetProject(projectID); err != nil {
+		return fmt.Errorf("could not find the project %q: %s", projectName, err)
+	}
+
+	b := &brigade.Build{
+		ProjectID: projectID,
+		Type:      event,
+		Provider:  "brigade-cli",
+		Revision: &brigade.Revision{
+			Commit: commitish,
+			Ref:    ref,
+		},
+		Payload:  payload,
+		Script:   data,
+		LogLevel: logLevel,
+	}
+	return a.SendBuild(b)
+}
+
+// waitForWorker waits until the worker has started.
+func (a *scriptRunner) waitForWorker(buildID string) error {
+	opts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("heritage=brigade,component=build,build=%s", buildID),
+	}
+	req, err := a.kc.CoreV1().Pods(a.namespace).Watch(opts)
+	if err != nil {
+		return err
+	}
+	res := req.ResultChan()
+
+	// Now we block until the Pod is ready
+	timeout := time.After(2 * time.Minute)
+	for {
+		select {
+		case e := <-res:
+			if a.verbose {
+				d, _ := json.MarshalIndent(e.Object, "", "  ")
+				fmt.Printf("Event: %s\n %s\n", e.Type, d)
+			}
+			// If the pod is added or modified, check the phase and see if it is
+			// running or complete.
+			switch e.Type {
+			case "DELETED":
+				// This happens if a user directly kills the pod with kubectl.
+				return fmt.Errorf("worker %s was just deleted unexpectedly", buildID)
+			case "ADDED", "MODIFIED":
+				pod := e.Object.(*v1.Pod)
+				switch pod.Status.Phase {
+				// Unhandled cases are Unknown and Pending, both of which should
+				// cause the loop to spin.
+				case "Running", "Succeeded":
+					req.Stop()
+					return nil
+				case "Failed":
+					req.Stop()
+					return fmt.Errorf("pod failed to schedule: %s", pod.Status.Reason)
+				}
+			}
+		case <-timeout:
+			req.Stop()
+			return fmt.Errorf("timeout waiting for build %s to start", buildID)
+		}
+	}
+}
+
+func (a *scriptRunner) podLog(name string, w io.Writer) error {
+	req := a.kc.CoreV1().Pods(a.namespace).GetLogs(name, &v1.PodLogOptions{Follow: true})
+
+	readCloser, err := req.Timeout(waitTimeout).Stream()
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	if !a.noProgress {
+		progressLogs(w, readCloser)
+	}
+
+	_, err = io.Copy(w, readCloser)
+	return err
+}
+
+func (a *scriptRunner) GetBuild(bid string) (*brigade.Build, error) {
+	return a.store.GetBuild(bid)
+}
+
+func progressLogs(w io.Writer, r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	last := []byte{}
+	p := &progress.Indicator{
+		Interval: 200 * time.Millisecond,
+		Writer:   w,
+		Frames: []string{
+			"....",
+			"=...",
+			".=..",
+			"..=.",
+			"...=",
+			"....",
+			"...=",
+			"..=.",
+			".=..",
+			"=...",
+		},
+	}
+	started := false
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		if string(raw) == string(last) && logPattern.Match(raw) {
+			if started {
+				continue
+			}
+			name := strings.Fields(string(raw))
+			p.Start(name[len(name)-1])
+			started = true
+		} else {
+			if started {
+				p.Done("done")
+				started = false
+			}
+			w.Write(raw)
+			w.Write([]byte{'\n'})
+		}
+		last = raw
+	}
+}


### PR DESCRIPTION
You can write any code that reuses `brig run`, to delegate running distributed scripts onto brigade, but with a more efficient and type-safe way.

This is a backward-compatible change, irrelevant to the feature of `brig run` and `brig rerun` commands.

This tweaks the original implementation of `brig run`, removing global variable references, extracting almost all the logics of it into the brand-new `brigade/script` go pkg.
So that it can be imported by other golang projects.

The script runner is now named `DelegatedRunner`, to make it extra clear to users, that the runner delegates a script to brigade, rather than running it in place.

The basic usage of this pkg, and how the body of `brig run` look like now, is:

```
runner, err := script.NewDelegatedRunner(kc, destination, ns, noProgress, runInBackground, verbose)
if err != nil {
    return err
}

runner.SendScript(proj, script, event, commitish, ref, payload, logLevel)

runner.SendBuild(build)
```

Resolves #622