### PR TITLE
feat(lib): alternative destination for script runner logs

### DIFF
--- a/brig/cmd/brig/commands/rerun.go
+++ b/brig/cmd/brig/commands/rerun.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"errors"
 	"io/ioutil"
-
 	"os"
 
 	"github.com/spf13/cobra"
@@ -46,10 +45,11 @@ var rerun = &cobra.Command{
 			return err
 		}
 
-		a, err := script.NewDelegatedRunner(kc, os.Stdout, globalNamespace)
+		a, err := script.NewDelegatedRunner(kc, globalNamespace)
 		if err != nil {
 			return err
 		}
+		a.ScriptLogDestination = os.Stdout
 		a.NoProgress = runNoProgress
 		a.Background = runBackground
 		a.Verbose = globalVerbose

--- a/brig/cmd/brig/commands/run.go
+++ b/brig/cmd/brig/commands/run.go
@@ -102,10 +102,11 @@ var run = &cobra.Command{
 			return err
 		}
 
-		runner, err := script.NewDelegatedRunner(kc, destination, globalNamespace)
+		runner, err := script.NewDelegatedRunner(kc, globalNamespace)
 		if err != nil {
 			return err
 		}
+		runner.ScriptLogDestination = destination
 		runner.NoProgress = runNoProgress
 		runner.Background = runBackground
 		runner.Verbose = globalVerbose

--- a/pkg/script/delegated_runner.go
+++ b/pkg/script/delegated_runner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -26,12 +27,13 @@ const (
 	waitTimeout = 5 * time.Minute
 )
 
-func NewDelegatedRunner(c *kubernetes.Clientset, logDest io.Writer, namespace string) (*ScriptRunner, error) {
+func NewDelegatedRunner(c *kubernetes.Clientset, namespace string) (*ScriptRunner, error) {
 	app := &ScriptRunner{
-		store:          kube.New(c, namespace),
-		kc:             c,
-		namespace:      namespace,
-		logDestination: logDest,
+		store:                kube.New(c, namespace),
+		kc:                   c,
+		namespace:            namespace,
+		ScriptLogDestination: os.Stdout,
+		RunnerLogDestination: os.Stdout,
 	}
 	return app, nil
 }
@@ -41,7 +43,8 @@ type ScriptRunner struct {
 	kc        kubernetes.Interface
 	namespace string
 
-	logDestination io.Writer
+	ScriptLogDestination io.Writer
+	RunnerLogDestination io.Writer
 
 	NoProgress bool
 	Background bool
@@ -56,17 +59,17 @@ func (a *ScriptRunner) SendBuild(b *brigade.Build) error {
 	podName := fmt.Sprintf("brigade-worker-%s", b.ID)
 
 	if a.Background {
-		fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
+		fmt.Fprintf(a.RunnerLogDestination, "Build: %s, Worker: %s\n", b.ID, podName)
 		return nil
 	}
-	fmt.Printf("Event created. Waiting for worker pod named %q.\n", podName)
+	fmt.Fprintf(a.RunnerLogDestination, "Event created. Waiting for worker pod named %q.\n", podName)
 
 	if err := a.waitForWorker(b.ID); err != nil {
 		return err
 	}
 
-	fmt.Printf("Build: %s, Worker: %s\n", b.ID, podName)
-	return a.podLog(podName, a.logDestination)
+	fmt.Fprintf(a.RunnerLogDestination, "Build: %s, Worker: %s\n", b.ID, podName)
+	return a.podLog(podName, a.ScriptLogDestination)
 }
 
 func (a *ScriptRunner) SendScript(projectName string, data []byte, event, commitish, ref string, payload []byte, logLevel string) error {
@@ -109,7 +112,7 @@ func (a *ScriptRunner) waitForWorker(buildID string) error {
 		case e := <-res:
 			if a.Verbose {
 				d, _ := json.MarshalIndent(e.Object, "", "  ")
-				fmt.Printf("Event: %s\n %s\n", e.Type, d)
+				fmt.Fprintf(a.RunnerLogDestination, "Event: %s\n %s\n", e.Type, d)
 			}
 			// If the pod is added or modified, check the phase and see if it is
 			// running or complete.


### PR DESCRIPTION
`ScriptRunner` now exposes `ScriptLogDestination` for woker pod logs, and `RunnerLogDestination` for logs of the script runner itself.

This is a follow-up for #623 that was started from #622