### PR TITLE
Fix invalid_format for Git SSH Keys.

### DIFF
--- a/git-sidecar/rootfs/gitssh.sh
+++ b/git-sidecar/rootfs/gitssh.sh
@@ -3,7 +3,7 @@ extra=""
 
 if [ "" != "${BRIGADE_REPO_KEY}" ]; then
   KEY="./id_dsa"
-  echo ${BRIGADE_REPO_KEY} | sed 's/\$/\n/g' > $KEY
+  printf "%s" "$BRIGADE_REPO_KEY" | sed 's/\$/\n/g' > $KEY
   chmod 600 $KEY
   extra="-i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 fi


### PR DESCRIPTION
Fixes #646 

## The Problem
Please see #646 for a detailed explanation of the problem. The TLDR is:

```
/home/src # echo ${BRIGADE_REPO_KEY} | sed 's/\$/\n/g'
-----BEGIN RSA PRIVATE KEY----- MIIJKQI <snip> l4UmoT/ -----END RSA PRIVATE KEY-----
/home/src # printf "%s" "$BRIGADE_REPO_KEY" | sed 's/\$/\n/g'
-----BEGIN RSA PRIVATE KEY-----
MIIJKQI
<snip>
l4UmoT/
-----END RSA PRIVATE KEY-----
```

Note how the `echo` doesn't properly show the newlines, but `printf` does.

## This Solution

This seemed like a good solution because it works when the secret has explicit `$` values, or if we allow k8s to insert the newlines for us.

In both cases, it produces a key with the proper newlines.