### PR TITLE
fix(brigade.js): remove redundant/incorrect rootfs cp cmd destination

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -193,7 +193,7 @@ function acrBuild(e, project, tag) {
     builder.tasks.push(
       `cd ${i}`,
       `echo '========> Building ${i}'`,
-      `cp -av /mnt/brigade/share/${i}/rootfs ./rootfs`,
+      `cp -av /mnt/brigade/share/${i}/rootfs ./`,
       `az acr build -r ${registry} -t ${imgName} -t ${latest} .`,
       `echo '<======== Finished ${i}'`,
       `cd ..`


### PR DESCRIPTION
This was hit during a manual `"release_images"` run and fix confirmed by a rerun of same.