### PR TITLE
ref(Makefile/brigade.js): append .exe to Windows binary at build stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ docker-push: $(addsuffix -push,$(IMAGES))
 		echo "building $$os"; \
 		for arch in $(CX_ARCHS); do \
 			GOOS=$$os GOARCH=$$arch CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o ./bin/$*-$$os-$$arch ./$*/cmd/$*; \
-		done;\
+		done; \
+		if [ $$os == 'windows' ]; then \
+			mv ./bin/$*-$$os-$$arch ./bin/$*-$$os-$$arch.exe; \
+		fi; \
 	done
 
 .PHONY: build-release

--- a/brigade.js
+++ b/brigade.js
@@ -104,12 +104,9 @@ function releaseBrig(e, p, tag) {
   ];
 
   // Upload for each target that we support
-  for (const f of ["linux-amd64", "windows-amd64", "darwin-amd64"]) {
+  for (const f of ["linux-amd64", "windows-amd64.exe", "darwin-amd64"]) {
     var name = binName + "-" + f;
     var outname = name;
-    if (f == "windows-amd64") {
-      outname += ".exe"
-    }
     cx.tasks.push(`github-release upload -f ./bin/${name} -n ${outname} -t ${tag}`)  
   }
   console.log(cx.tasks);


### PR DESCRIPTION
Perhaps it would be valuable to append `.exe` at the build stage such that Windows developers don't have to rename when building locally, as opposed to renaming at the release stage.  