### PR TITLE
Kubernetes error caused by Job.env{} empty var

### DIFF
--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -281,6 +281,11 @@ export class JobRunner implements jobs.JobRunner {
             }
           }
         } as kubernetes.V1EnvVar);
+      } else if (val === null) {
+        envVars.push({
+          name: key,
+          value: ""
+        } as kubernetes.V1EnvVar); 
       } else {
         // For environmental variables that are directly references,
         // add the reference to the env var list.


### PR DESCRIPTION
Fixes issue #469. 

Added a check for `null` which will set `value` in Kubernetes pod env section to an empty string, instead of the default behavior indicated in issue #469 which was invalid and would cause an error. 

Please note I had some problems getting the dev environment set up, and haven't been able to test this locally as of yet. 