### PR TITLE
Fix golint warning: redundant if ...; err != nil check, just return error instead.

### DIFF
--- a/brig/cmd/brig/commands/project_create.go
+++ b/brig/cmd/brig/commands/project_create.go
@@ -157,10 +157,7 @@ func createProject(out io.Writer) error {
 	}
 
 	// Store the project
-	if err := store.CreateProject(proj); err != nil {
-		return err
-	}
-	return nil
+	return store.CreateProject(proj)
 }
 
 // projectCreatePrompts handles all of the prompts.


### PR DESCRIPTION
Assigning the error and making a conditional if on it and returning nil in the end is more work than just returning the error and as the method `store.CreateProject(proj)` already returns the error we could avoid that.