### PR TITLE
Added job name length check in job constructor

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -243,7 +243,7 @@ export abstract class Job {
   ) {
     if (!jobNameIsValid(name)) {
       throw new Error(
-        "job name must be letters, numbers, and '-', and must not start or end with '-'"
+        "job name must be letters, numbers, and '-', and must not start or end with '-', having max length 36"
       );
     }
     this.name = name.toLocaleLowerCase();
@@ -270,5 +270,5 @@ export abstract class Job {
  * jobNameIsValid checks the validity of a job's name.
  */
 export function jobNameIsValid(name: string): boolean {
-  return /^(([a-z0-9][-a-z0-9.]*)?[a-z0-9])+$/.test(name);
+  return (name.length < 37) && /^(([a-z0-9][-a-z0-9.]*)?[a-z0-9])+$/.test(name);
 }

--- a/brigade-worker/test/job.ts
+++ b/brigade-worker/test/job.ts
@@ -96,6 +96,14 @@ describe("job", function() {
         j = new mock.MockJob("name");
         assert.equal(j.host.nodeSelector.size, 0);
       });
+      it("longer than expected name", function(done){
+       try {
+        new mock.MockJob("justmakingthesethirtysevencharacterss");
+        done("Expecting to fail for more than 36 characters");
+       } catch (error) {
+         done();
+       }
+      });
       context("when image is supplied", function() {
         it("sets image property", function() {
           j = new mock.MockJob("my-name", "alpine:3.4");


### PR DESCRIPTION
Job seems to be correct place to implement name check instead of
brigadier. And there are other checks on job name.

fixes #679 
