### PR TITLE
feat(controller): export NewWorkerPod

### DIFF
--- a/brigade-controller/cmd/brigade-controller/controller/handler_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/handler_test.go
@@ -5,19 +5,16 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestNewWorkerPod_Defaults(t *testing.T) {
 	build := &v1.Secret{}
 	proj := &v1.Secret{}
-	client := fake.NewSimpleClientset()
 	config := &Config{
 		Namespace: v1.NamespaceDefault,
 	}
 
-	c := NewController(client, config)
-	pod := c.newWorkerPod(build, proj)
+	pod := NewWorkerPod(build, proj, config)
 
 	spec := pod.Spec
 	if spec.NodeSelector["beta.kubernetes.io/os"] != "linux" {


### PR DESCRIPTION
It exposes NewWorkerPod from controller, so that a custom controller can call it (related to #662 ).
We could have it in a separate repository under Azure in the future, if necessary though.
Please let me know your thoughts on this.