### PR TITLE
ref(brigade-worker): don't supply a default ref

### DIFF
--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -62,7 +62,7 @@ let e: events.BrigadeEvent = {
   provider: process.env.BRIGADE_EVENT_PROVIDER || "unknown",
   revision: {
     commit: process.env.BRIGADE_COMMIT_ID,
-    ref: process.env.BRIGADE_COMMIT_REF || "refs/heads/master"
+    ref: process.env.BRIGADE_COMMIT_REF
   },
   logLevel: logLevel
 };


### PR DESCRIPTION
This is more of a PR/proposal hybrid, seeking feedback.

I've encountered the case recently while handling the `check_suite`/`check_run` webhooks courtesy GitHub's Checks API (via the [brigade-github-app](https://github.com/Azure/brigade-github-app)) wherein the ref (or, `head_branch` for these particular webhooks) is `null`.  

Frequently, the check suite/run is for a PR from a fork, or at least a topic branch.  Therefore, although the initial `brigade-worker` pod runs fine with the ref as `null` (it simply defers to the commit SHA provided), it then passes a default of `refs/heads/master` to all Job pods.  Note that a provided ref currently takes precedence over the provided commit SHA, as seen in `git-sidecar`'s [clone.sh](https://github.com/Azure/brigade/blob/master/git-sidecar/rootfs/clone.sh) script.

As a result, the pods run their tasks (build,test,etc.) off of `refs/heads/master` and _not_ the intended commit/branch.

Therefore, I'm wondering if it might be possible to stop providing this default?  And/or, otherwise "do the right thing" when handling webhooks where `ref`/`headBranch` may be null/empty and the provided commit may be on a topic branch/fork/etc.

Thoughts @adamreese ?