### PR TITLE
Add resource limits to job

### DIFF
--- a/brigade-worker/src/job.ts
+++ b/brigade-worker/src/job.ts
@@ -135,12 +135,22 @@ export class JobDockerMount {
 }
 
 /**
- * JObResourceRequest represents request of the resources
+ * JobResourceRequest represents request of the resources
  */
 export class JobResourceRequest {
   /** cpu requests */
   public cpu: string;
   /** memory requests */
+  public memory: string;
+}
+
+/**
+ * JobResourceLimit represents limit of the resources
+ */
+export class JobResourceLimit {
+  /** cpu limits */
+  public cpu: string;
+  /** memory limits */
   public memory: string;
 }
 
@@ -199,6 +209,9 @@ export abstract class Job {
 
   /** Set the resource requests for the containers */
   public resourceRequests: JobResourceRequest;
+
+  /** Set the resource limits for the containers */
+  public resourceLimits: JobResourceLimit;
 
   /**
    * host expresses expectations about the host the job will run on.
@@ -260,6 +273,7 @@ export abstract class Job {
     this.docker = new JobDockerMount();
     this.host = new JobHost();
     this.resourceRequests = new JobResourceRequest();
+    this.resourceLimits = new JobResourceLimit();
   }
 
   /** run executes the job and then */

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -148,6 +148,24 @@ describe("k8s", function() {
           });
         });
       });
+      context("when resources are specified", function() {
+        beforeEach(function() {
+          j.resourceRequests.cpu = "250m";
+          j.resourceRequests.memory = "512Mi";
+          j.resourceLimits.cpu = "500m";
+          j.resourceLimits.memory = "1Gi";
+        });
+        it("sets resource requests and limits for the container pod", function() {
+          let jr = new k8s.JobRunner(j, e, p);
+          let expResources = new kubernetes.V1ResourceRequirements();
+          expResources.requests = { cpu: "250m", memory: "512Mi" };
+          expResources.limits = { cpu: "500m", memory: "1Gi" };
+          assert.deepEqual(
+            jr.runner.spec.containers[0].resources,
+            expResources
+          );
+        });
+      });
       context("when service account is specified", function() {
         beforeEach(function() {
           j.serviceAccount = "svcAccount";

--- a/docs/topics/javascript.md
+++ b/docs/topics/javascript.md
@@ -22,7 +22,6 @@ Brigade files respond to _events_. That is, Brigade scripts are typically compos
 more _event handlers_. When the Brigade environment triggers an event, the associated
 event handler will be called.
 
-
 ## The `brigadier` Library
 
 The main library for Brigade is called `brigadier`. The Brigade runtime grants access to
@@ -55,7 +54,7 @@ An instance of an `BrigadeEvent` has the following properties:
 - `buildID: string`: The unique ID for the build. This will change for each build.
 - `type: string`: The event type (`push`, `exec`, `pull_request`).
 - `provider: string`: The name of the thing that triggered this event.
-- `revision: Revision`: The revision details, if supplied, of the underlying VCS system.  
+- `revision: Revision`: The revision details, if supplied, of the underlying VCS system.
 - `payload: string`: Arbitrary data supplied by an event emitter. Each event emitter
   will describe its own payload. For example, the GitHub gateway emits events that
   contain GitHub's webhook objects.
@@ -95,8 +94,8 @@ when the named event fires.
 
 ```javascript
 events.on("push", (e, p) => {
-  console.log(p.name)
-})
+  console.log(p.name);
+});
 ```
 
 #### `events.has(eventName: string): boolean`
@@ -169,11 +168,11 @@ defaults.
 These two are equivalent:
 
 ```javascript
-var one = new Job("one")
-one.image = "alpine:3.4"
-one.tasks = ["echo hello"]
+var one = new Job("one");
+one.image = "alpine:3.4";
+one.tasks = ["echo hello"];
 
-var two = new Job("two", "alpine:3.4", ["echo hello"])
+var two = new Job("two", "alpine:3.4", ["echo hello"]);
 ```
 
 Properties of `Job`
@@ -198,6 +197,24 @@ Properties of `Job`
 - `docker: JobDockerMount`: Preferences for mounting a Docker socket
 - `serviceAccount: string`: The name of the service account to use (if you need to override the default).
 - `annotations: {[key: string]:string}`: Name/value pairs of annotations to add to the job's pod
+- `resourceRequests: JobResourceRequest`: CPU and memory request resources for the job pod container.
+- `resourceLimits: JobResourceLimit`: CPU and memory limit resources for the job pod container.
+
+#### Setting execution resources to a job
+
+For some jobs is a good practice to set limits and guarantee some resources. In the following example job pod container resource requests and limits are set.
+
+```javascript
+var job = new Job("huge-job");
+
+// Our job uses a lot of resources, we set huge requests but set safe memory limits:
+job.resourceRequests.memory = "2Gi";
+job.resourceRequests.cpu = "500m";
+job.resourceLimits.memory = "3Gi";
+job.resourceLimits.cpu = "1";
+```
+
+All are optional, for example you could set only `resourceLimits.memory = 3Gi`).
 
 #### The `job.podName()` method
 
@@ -244,11 +261,11 @@ A `JobHost` object provides preferences for the host upon which the job is execu
 
 ### The `JobStorage` class
 
-- `enabled: boolean`: If set to `true `, the Job will mount the build storage.
-   Build storage exposes a mounted volume at `/mnt/brigade/share` with storage that
-   can be shared across jobs.
+- `enabled: boolean`: If set to `true`, the Job will mount the build storage.
+  Build storage exposes a mounted volume at `/mnt/brigade/share` with storage that
+  can be shared across jobs.
 - `path: string`: The read-only path to the shared storage from within the container.
-   EXPERIMENTAL: Support for setting the `path` was added in Brigade 0.15.
+  EXPERIMENTAL: Support for setting the `path` was added in Brigade 0.15.
 
 ### The `KubernetesConfig` class
 
@@ -271,12 +288,12 @@ This returns the result as a string.
 
 Properties:
 
-  - `id: string`: The unique ID of the project
-  - `name: string`: The project name, typically `org/name`.
-  - `kubernetes: KubernetesConfig`: The object describing this project's Kubernetes settings
-  - `repo: Repository`: Information on the upstream repository (if available).
-  - `secrets: {[key: string]: string}`: Key/value pairs of secret name and secret value.
-    The security model _may_ limit access to this property or its values.
+- `id: string`: The unique ID of the project
+- `name: string`: The project name, typically `org/name`.
+- `kubernetes: KubernetesConfig`: The object describing this project's Kubernetes settings
+- `repo: Repository`: Information on the upstream repository (if available).
+- `secrets: {[key: string]: string}`: Key/value pairs of secret name and secret value.
+  The security model _may_ limit access to this property or its values.
 
 Secrets (`project.secrets`) are passed from the project configuration into a Kubernetes Secret, then injected into Brigade.
 
@@ -295,13 +312,12 @@ Properties:
 - `payload`: The object received from the event trigger. For GitHub requests, its
   the data we get from GitHub.
 
-
 ### The `Job` object
 
 To create a new job:
 
 ```javascript
-j = new Job(name)
+j = new Job(name);
 ```
 
 Parameters:
@@ -324,31 +340,31 @@ Properties:
   - Example:
     ```javascript
     myJob.env = {
-        myOneOffSecret: "secret value",
-        myConfigReference: {
-            configMapKeyRef: {
-                name: "my-configmap",
-                key: "my-configmap-key"
-            }
-        },
-        mySecretReference: {
-            secretKeyRef: {
-                name: "my-secret",
-                key: "my-secret-key"
-            }
+      myOneOffSecret: "secret value",
+      myConfigReference: {
+        configMapKeyRef: {
+          name: "my-configmap",
+          key: "my-configmap-key"
         }
-    }
+      },
+      mySecretReference: {
+        secretKeyRef: {
+          name: "my-secret",
+          key: "my-secret-key"
+        }
+      }
+    };
     ```
 
 It is common to pass data from the `e.env` Event object into the Job object as is appropriate:
 
 ```javascript
 events.push = function(e) {
-  j = new Job("example")
-  j.env = { "DB_PASSWORD": project.secrets.dbPassword }
+  j = new Job("example");
+  j.env = { DB_PASSWORD: project.secrets.dbPassword };
   //...
-  j.run()
-}
+  j.run();
+};
 ```
 
 The above will make `$DB_PASSWORD` available to the "example" job's runtime.


### PR DESCRIPTION
Now we can add also resource limits to the jobs:

```js
job.resourceRequests.memory = "3Gi";
job.resourceRequests.cpu = "1";
job.resourceLimits.memory = "6Gi";
job.resourceLimits.cpu = "3";
```

Also fixes the issue of only setting request resources on the container pod specif you set CPU **and** memory. Now if any of those two exist it sets the ones described.

Updated the docs to show how to add resources to the jobs
