### PR TITLE
brig build delete BuildID and brig build delete-all ProjectID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -357,11 +357,12 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:11705e15791a8855c4b81839cbd71722b82f0304bf5e4225c878e6961c0d4c25"
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = ""
-  revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
   digest = "1:cb2800cd5716e9d6172888e0e3ffe1f9c07b7f142eb83d49a391029bcf4f6cc1"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,181 +2,234 @@
 
 
 [[projects]]
+  digest = "1:b24249f5a5e6fbe1eddc94b25973172339ccabeadef4779274f3ed0167c18812"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
+  pruneopts = ""
   revision = "2d3a6656c17a60b0815b7e06ab0be04eacb6e613"
   version = "v0.16.0"
 
 [[projects]]
+  digest = "1:a6487ef53b8f41197ed24e00b69ede54a6c75b387728b70d873b8922bb112335"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date"
+    "autorest/date",
   ]
+  pruneopts = ""
   revision = "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
   version = "v8.0.0"
 
 [[projects]]
+  digest = "1:24cff84fefa06791f78f9bc6e05c2a3a90710c81ae6b76225280daf33b267d36"
   name = "github.com/Masterminds/goutils"
   packages = ["."]
+  pruneopts = ""
   revision = "3391d3790d23d03408670993e957e8f408993c34"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:06536c81205ec25a10bc0782a9720483e10463365c2fedc712bf180c457ba99a"
   name = "github.com/Masterminds/kitt"
   packages = ["progress"]
+  pruneopts = ""
   revision = "7e843d5f21a5f009f5119a91ea3868eabb19b20f"
 
 [[projects]]
+  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = ""
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:331a419049c2be691e5ba1d24342fc77c7e767a80c666a18fd8a9f7b82419c1c"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = ""
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:9d013c04ff3012769abc7ea289948bf93bf82e8b22c5909f031127647609523f"
   name = "github.com/bacongobbler/browser"
   packages = ["."]
+  pruneopts = ""
   revision = "792d0443b3e34e0a99a68e254084079ad9356db5"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:9a62b6bb832d61f198b4301a6ecb4fbef21a731596bb21c27e27f79b1e8260d7"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "782f4967f2dc4564575ca782fe2d04090b5faca8"
 
 [[projects]]
+  digest = "1:22edc748e904e914338a825c46dcdb357821514ca2d1d6f3f1bad506562e230f"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "01aeca54ebda6e0fbfafd0a524d234159c05ec20"
 
 [[projects]]
   branch = "master"
+  digest = "1:6c48291ff15f3c3b263ed6f7356acea45da69e7fca8d0d76d2c021a075fbd52a"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy"
+    "spdy",
   ]
+  pruneopts = ""
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
+  digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = ""
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
 
 [[projects]]
+  digest = "1:4686dac58ca038b57a4dfd785f4d1d0548b21c4e61d2f2dd51a20073c89aaf38"
   name = "github.com/emicklei/go-restful-openapi"
   packages = ["."]
+  pruneopts = ""
   revision = "51bf251d405ad1e23511fef0a2dbe40bc70ce2c6"
   version = "v0.11.0"
 
 [[projects]]
+  digest = "1:a31fbb19d2b38d50bc125d97b7c3e7a286d3f6f37d18756011eb6e7d1a9fa7d0"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 
 [[projects]]
   branch = "master"
+  digest = "1:1120f960f5c334f0f94bad29eefaf73d52d226893369693686148f66c1993f15"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
+  pruneopts = ""
   revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
 
 [[projects]]
+  digest = "1:fd621adc32cca47cc7bfc512e2b527b0fa8a278722f325531a2be1c205b37be1"
   name = "github.com/gin-gonic/gin"
   packages = [
     "binding",
     "json",
-    "render"
+    "render",
   ]
+  pruneopts = ""
   revision = "d39ed41ab3795346f5f843ec31bc0138be07eaab"
 
 [[projects]]
+  digest = "1:e116a4866bffeec941056a1fcfd37e520fad1ee60e4e3579719f19a43c392e10"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = ""
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
   version = "0.15.0"
 
 [[projects]]
+  digest = "1:3830527ef0f4f9b268d9286661c0f52f9115f8aefd9f45ee7352516f93489ac9"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = ""
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
   version = "0.15.0"
 
 [[projects]]
+  digest = "1:6caee195f5da296689270037c5a25c0bc3cc6e54ae5a356e395aa8946356dbc9"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = ""
   revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
   version = "0.15.0"
 
 [[projects]]
+  digest = "1:22da48dbccb0539f511efbbbdeba68081866892234e57a9d7c7f9848168ae30c"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = ""
   revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
   version = "0.15.0"
 
 [[projects]]
+  digest = "1:91ea659283519bfbcc8d428ecbae5475394a48f8209f5c5cd20fee169b37a63a"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = ""
   revision = "c0656edd0d9eab7c66d1eb0c568f9039345796f7"
 
 [[projects]]
+  digest = "1:ed314700d20eeaaa904b47e6fd3d4866f7bd14887a4904a9f69ec1e47385416f"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "44145f04b68cf362d9c4df2182967c2275eaefed"
 
 [[projects]]
+  digest = "1:5126907b5a6192e00ab27ceae807c53d7ff61343f15308dbe09621d12231da02"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = ""
   revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
 
 [[projects]]
   branch = "master"
+  digest = "1:0022cff7d0dd79dbfa78ce16fea20fb29d6fdfcfae67ee55cada2e422cedf8ee"
   name = "github.com/google/go-github"
   packages = ["github"]
+  pruneopts = ""
   revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
 
 [[projects]]
   branch = "master"
+  digest = "1:9abc49f39e3e23e262594bb4fb70abf74c0c99e94f99153f43b143805e850719"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = ""
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
+  digest = "1:a2823c34933d4a2b36284f617f483d51fe156a443923284b3660f183dcfa3338"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 
 [[projects]]
+  digest = "1:71997b5636a4e8502af4ba1c88abf935e6e47bf845d109ebafb9da1269f3be30"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = ""
   revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
 
 [[projects]]
+  digest = "1:e55663349fbfe58602ec7ebfb447aeda92f2717af3070d9451df3204b6093a7e"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -185,112 +238,147 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/utils",
-    "pagination"
+    "pagination",
   ]
+  pruneopts = ""
   revision = "2bf16b94fdd9b01557c4d076e567fe5cbbe5a961"
 
 [[projects]]
   branch = "master"
+  digest = "1:b4e7b1e55d849b7d1a4d96d1a029141d7ac963b4403e6ddb1cdb6e5384ab4781"
   name = "github.com/gosuri/uitable"
   packages = [
     ".",
     "util/strutil",
-    "util/wordwrap"
+    "util/wordwrap",
   ]
+  pruneopts = ""
   revision = "36ee7e946282a3fb1cfecd476ddc9b35d8847e42"
 
 [[projects]]
+  digest = "1:9830c3ef8075a224fca4ed2d3761b58b3759310343d028223779dea21e139893"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = ""
   revision = "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
 
 [[projects]]
   branch = "master"
+  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = ""
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:af7e132906cb360f4d7c34a9e1434825467f21c4ff5c521ad4cc5b55352876a8"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:3bfa8de14223d7f2f1f313ca82b87d79b43cf530c665db85f374b55857ffc443"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = ""
   revision = "36b14963da70d11297d313183d7e6388c8510e1e"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d9e483f4b9e306facf126bd90b02d512bd22ea4471e1568867e32221a8abbb16"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = ""
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
+  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:cb9bf7b99ca4343dbc494abbbfc4f43d883927207edee12438a20ea3e839d245"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
+  pruneopts = ""
   revision = "d6bea18f789704b5f83375793155289da36a3c7f"
   version = "v0.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:50416da10e189bc201e122e20078fb8e680a439cbdd24aaece06c434b4415b60"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = ""
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:ef57aecdf87b09455aeab4413d7e2cd15a0021fddfaa654ffb74cf266068788b"
   name = "github.com/oklog/ulid"
   packages = ["."]
+  pruneopts = ""
   revision = "d311cb43c92434ec4072dfbbda3400741d0a6337"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "f62e98d28ab7ad31d707ba837a966378465c7b57"
+  pruneopts = ""
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
+  digest = "1:11705e15791a8855c4b81839cbd71722b82f0304bf5e4225c878e6961c0d4c25"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
 
 [[projects]]
+  digest = "1:cb2800cd5716e9d6172888e0e3ffe1f9c07b7f142eb83d49a391029bcf4f6cc1"
   name = "github.com/ugorji/go"
   packages = ["codec"]
+  pruneopts = ""
   revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
 
 [[projects]]
+  digest = "1:67deb33ca789e9ac4f07820a4a0f9725e66e3913af6bfd7231328eb3cad3377c"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "81e90905daefcd6fd217b62423c0908922eadb30"
 
 [[projects]]
+  digest = "1:35171304d8332a0cfac5f3bd9222467f036732ddde75c65278b16f65216e03ed"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -298,30 +386,36 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex"
+    "lex/httplex",
   ]
+  pruneopts = ""
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
+  digest = "1:17714ac6482dac2cbc92c7fa82a30812b27c79c6fcaaff5784df4f583ac439a4"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = ""
   revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
 
 [[projects]]
+  digest = "1:19adc71218d62052cd18b83ebaab77961378876094081f4b1581ca28ef80395d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce"
 
 [[projects]]
+  digest = "1:75a8b2050f6576c5ebc0f4985ad976cca7e4c1834c73a2a15d522a2d8d143963"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -333,17 +427,21 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = ""
   revision = "b19bf474d317b857955b12035d2c5acb57ce8b01"
 
 [[projects]]
   branch = "master"
+  digest = "1:55a681cb66f28755765fa5fa5104cbd8dc85c55c02d206f9f89566451e3fe1aa"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = ""
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
+  digest = "1:7b693deb3738e3bcfccbb74cb8033878a6a32189e882a0fbc0407617fdf2dbed"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -355,45 +453,57 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = ""
   revision = "12d5545dc1cfa6047a286d5e853841b6471f4c19"
 
 [[projects]]
+  digest = "1:6495dc6b09c6e9c4602312d16284aac80b51c7fd9d39f706bb73a667c2ba5901"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
     "core",
-    "terminal"
+    "terminal",
   ]
+  pruneopts = ""
   revision = "17861e192dc11fd2f5081df1932c94cce262fa1e"
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:348ceb76f2ac958e541e4ba3190484b68df28c38ac9720ed4ef8d36af69ce52e"
   name = "gopkg.in/gin-gonic/gin.v1"
   packages = ["."]
+  pruneopts = ""
   revision = "d459835d2b077e44f7c9b453505ee29881d5d12d"
   version = "v1.2"
 
 [[projects]]
+  digest = "1:2309de6560092423515cfddf30d0e7bff3e742cd805df80005f6309f0621ba36"
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
+  pruneopts = ""
   revision = "5f57d2222ad794d0dffb07e664ea05e2ee07d60c"
   version = "v8.18.1"
 
 [[projects]]
+  digest = "1:e5d1fb981765b6f7513f793a3fcaac7158408cca77f75f7311ac82cc88e9c445"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:10cf86195bddd2e0d686eec4fb35f35510baf6ce8393cbcfb664b9b88db7d747"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 
 [[projects]]
   branch = "release-1.10"
+  digest = "1:5beb32094452970c0d73a2bdacd79aa9cfaa4947a774d521c1bed4b4c2705f15"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -423,12 +533,14 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = ""
   revision = "8b7507fac302640dd5f1efbf9643199952cc58db"
 
 [[projects]]
   branch = "release-1.10"
+  digest = "1:ddf1cbe17938e59f1f5d7caa57c03382a450fdc5c91e5852ff89802c8b27b459"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -472,12 +584,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = ""
   revision = "17529ec7eadb8de8e7dc835201455f53571f655a"
 
 [[projects]]
   branch = "release-7.0"
+  digest = "1:3a45889089f89cc371fb45b3f8a478248b755e4af17a8cf592e49bdf3481a0b3"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -573,13 +687,49 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = ""
   revision = "26a26f55b28aa1b338fbaf6fbbe0bcd76aed05e0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "244646581bd1134d40731a24d89c5c2f58da0b96cd29919a51bfe162d166d179"
+  input-imports = [
+    "github.com/Masterminds/goutils",
+    "github.com/Masterminds/kitt/progress",
+    "github.com/bacongobbler/browser",
+    "github.com/emicklei/go-restful",
+    "github.com/emicklei/go-restful-openapi",
+    "github.com/go-openapi/spec",
+    "github.com/google/go-github/github",
+    "github.com/gosuri/uitable",
+    "github.com/oklog/ulid",
+    "github.com/spf13/cobra",
+    "golang.org/x/oauth2",
+    "gopkg.in/AlecAivazis/survey.v1",
+    "gopkg.in/gin-gonic/gin.v1",
+    "gopkg.in/yaml.v2",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/util/duration",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/util/yaml",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/plugin/pkg/client/auth",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/portforward",
+    "k8s.io/client-go/transport/spdy",
+    "k8s.io/client-go/util/workqueue",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/brig/cmd/brig/commands/build_delete.go
+++ b/brig/cmd/brig/commands/build_delete.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const buildDeleteUsage = `Deletes a build.`
+const buildDeleteUsage = `Deletes a build and its corresponding jobs.`
 
 var forceDeleteRunning bool
 

--- a/brig/cmd/brig/commands/build_delete.go
+++ b/brig/cmd/brig/commands/build_delete.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"errors"
+	"io"
+
+	"github.com/Azure/brigade/pkg/storage"
+	"github.com/Azure/brigade/pkg/storage/kube"
+
+	"github.com/spf13/cobra"
+)
+
+const buildDeleteUsage = `Deletes a build, regardless of its state.`
+
+func init() {
+	build.AddCommand(buildDelete)
+}
+
+var buildDelete = &cobra.Command{
+	Use:   "delete BUILD_ID",
+	Short: "deletes build",
+	Long:  buildDeleteUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return errors.New("build ID is a required argument")
+		}
+		return deleteBuild(cmd.OutOrStdout(), args[0])
+	},
+}
+
+func deleteBuild(out io.Writer, bid string) error {
+	c, err := kubeClient()
+	if err != nil {
+		return err
+	}
+
+	store := kube.New(c, globalNamespace)
+	err = store.DeleteBuild(bid, storage.DeleteBuildOptions{
+		SkipRunningBuilds: false,
+	})
+	return err
+}

--- a/brig/cmd/brig/commands/build_delete.go
+++ b/brig/cmd/brig/commands/build_delete.go
@@ -23,6 +23,7 @@ var buildDelete = &cobra.Command{
 	Use:   "delete BUILD_ID",
 	Short: "deletes build",
 	Long:  buildDeleteUsage,
+	Args:  cobra.ExactArgs(1)
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("build ID is a required argument")

--- a/brig/cmd/brig/commands/build_delete.go
+++ b/brig/cmd/brig/commands/build_delete.go
@@ -10,10 +10,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const buildDeleteUsage = `Deletes a build, regardless of its state.`
+const buildDeleteUsage = `Deletes a build.`
+
+var forceDeleteRunning bool
 
 func init() {
 	build.AddCommand(buildDelete)
+	buildDelete.Flags().BoolVar(&forceDeleteRunning, "force", false, "If set, will also delete running builds. Default: false")
 }
 
 var buildDelete = &cobra.Command{
@@ -35,8 +38,7 @@ func deleteBuild(out io.Writer, bid string) error {
 	}
 
 	store := kube.New(c, globalNamespace)
-	err = store.DeleteBuild(bid, storage.DeleteBuildOptions{
-		SkipRunningBuilds: false,
+	return store.DeleteBuild(bid, storage.DeleteBuildOptions{
+		SkipRunningBuilds: !forceDeleteRunning,
 	})
-	return err
 }

--- a/brig/cmd/brig/commands/build_delete.go
+++ b/brig/cmd/brig/commands/build_delete.go
@@ -23,7 +23,7 @@ var buildDelete = &cobra.Command{
 	Use:   "delete BUILD_ID",
 	Short: "deletes build",
 	Long:  buildDeleteUsage,
-	Args:  cobra.ExactArgs(1)
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("build ID is a required argument")

--- a/brig/cmd/brig/commands/build_delete_all.go
+++ b/brig/cmd/brig/commands/build_delete_all.go
@@ -10,15 +10,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const buildDeleteAllUsage = `Deletes all non-running builds for a project.`
+const buildDeleteAllUsage = `Deletes all builds for a project.`
+
+var forceDeleteRunningAll bool
 
 func init() {
 	build.AddCommand(buildDeleteAll)
+	buildDeleteAll.Flags().BoolVar(&forceDeleteRunningAll, "force", false, "If set, will also delete running builds. Default: false")
 }
 
 var buildDeleteAll = &cobra.Command{
 	Use:   "delete-all PROJECT_ID",
-	Short: "deletes all non-running builds for a project",
+	Short: "deletes all builds for a project",
 	Long:  buildDeleteAllUsage,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -49,8 +52,10 @@ func deleteAllBuilds(out io.Writer, projectID string) error {
 	var errDeletes error
 	for _, b := range builds {
 		err = store.DeleteBuild(b.ID, storage.DeleteBuildOptions{
-			SkipRunningBuilds: false,
+			SkipRunningBuilds: !forceDeleteRunningAll,
 		})
+		// loop will continue even if an error is encountered
+		// maybe add a check => "if errorCount > threshold then return"?
 		if err != nil {
 			if errDeletes == nil {
 				errDeletes = errors.New("")

--- a/brig/cmd/brig/commands/build_delete_all.go
+++ b/brig/cmd/brig/commands/build_delete_all.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const buildDeleteAllUsage = `Deletes all builds for a project.`
+const buildDeleteAllUsage = `Deletes all builds for a project as well as their corresponding jobs.`
 
 var forceDeleteRunningAll bool
 

--- a/brig/cmd/brig/commands/build_delete_all.go
+++ b/brig/cmd/brig/commands/build_delete_all.go
@@ -23,7 +23,7 @@ var buildDeleteAll = &cobra.Command{
 	Use:   "delete-all PROJECT_ID",
 	Short: "deletes all builds for a project",
 	Long:  buildDeleteAllUsage,
-	Args:  cobra.ExactArgs(1)
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("project ID is a required argument")

--- a/brig/cmd/brig/commands/build_delete_all.go
+++ b/brig/cmd/brig/commands/build_delete_all.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"errors"
+	"io"
+
+	"github.com/Azure/brigade/pkg/storage"
+	"github.com/Azure/brigade/pkg/storage/kube"
+
+	"github.com/spf13/cobra"
+)
+
+const buildDeleteAllUsage = `Deletes all non-running builds for a project.`
+
+func init() {
+	build.AddCommand(buildDeleteAll)
+}
+
+var buildDeleteAll = &cobra.Command{
+	Use:   "delete-all PROJECT_ID",
+	Short: "deletes all non-running builds for a project",
+	Long:  buildDeleteAllUsage,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return errors.New("project ID is a required argument")
+		}
+		return deleteAllBuilds(cmd.OutOrStdout(), args[0])
+	},
+}
+
+func deleteAllBuilds(out io.Writer, projectID string) error {
+	c, err := kubeClient()
+	if err != nil {
+		return err
+	}
+
+	store := kube.New(c, globalNamespace)
+
+	proj, err := store.GetProject(projectID)
+	if err != nil {
+		return err
+	}
+
+	builds, err := store.GetProjectBuilds(proj)
+	if err != nil {
+		return err
+	}
+
+	var errDeletes error
+	for _, b := range builds {
+		err = store.DeleteBuild(b.ID, storage.DeleteBuildOptions{
+			SkipRunningBuilds: false,
+		})
+		if err != nil {
+			if errDeletes == nil {
+				errDeletes = errors.New("")
+			}
+			errDeletes = errors.New(errDeletes.Error() + err.Error())
+		}
+	}
+
+	return errDeletes
+}

--- a/brig/cmd/brig/commands/build_delete_all.go
+++ b/brig/cmd/brig/commands/build_delete_all.go
@@ -23,6 +23,7 @@ var buildDeleteAll = &cobra.Command{
 	Use:   "delete-all PROJECT_ID",
 	Short: "deletes all builds for a project",
 	Long:  buildDeleteAllUsage,
+	Args:  cobra.ExactArgs(1)
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return errors.New("project ID is a required argument")

--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -42,6 +42,18 @@ is happening. You might prefer to checkout the most recent stable tag:
 
 - `$ git checkout v0.18.0`
 
+After cloning, you should run this command to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
+
+```bash
+git remote add fork https://github.com/<GitHub username>/brigade
+```
+
+To push your changes to your fork, you should use:
+
+```bash
+git push --set-remote fork <branch>
+```
+
 ## Building Source
 
 To build all of the source, run this:

--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -42,18 +42,6 @@ is happening. You might prefer to checkout the most recent stable tag:
 
 - `$ git checkout v0.18.0`
 
-After cloning, you should run this command to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
-
-```bash
-git remote add fork https://github.com/<GitHub username>/brigade
-```
-
-To push your changes to your fork, you should use:
-
-```bash
-git push --set-upstream fork <branch>
-```
-
 ## Building Source
 
 To build all of the source, run this:

--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -51,7 +51,7 @@ git remote add fork https://github.com/<GitHub username>/brigade
 To push your changes to your fork, you should use:
 
 ```bash
-git push --set-remote fork <branch>
+git push --set-upstream fork <branch>
 ```
 
 ## Building Source

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -53,7 +53,7 @@ func (s *store) DeleteBuild(bid string, options storage.DeleteBuildOptions) erro
 		for _, p := range pods.Items {
 			if p.Labels["component"] == "build" {
 				if p.Status.Phase == v1.PodRunning || p.Status.Phase == v1.PodPending {
-					log.Printf("skipping Build %s because it is on Status %s", p.Labels["build"], p.Status.Phase)
+					log.Printf("skipping Build %s because its Status is %s", p.Labels["build"], p.Status.Phase)
 					return nil
 				}
 			}

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -1,19 +1,25 @@
 package kube
 
 import (
+	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 	"time"
 
+	"github.com/Azure/brigade/pkg/brigade"
+	"github.com/Azure/brigade/pkg/storage"
+
 	"github.com/oklog/ulid"
+
 	"k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/Azure/brigade/pkg/brigade"
 )
 
 const secretTypeBuild = "brigade.sh/build"
+
+const jobFilter = "component in (build, job), heritage = brigade, build = %s"
 
 // GetBuild returns the build.
 func (s *store) GetBuild(id string) (*brigade.Build, error) {
@@ -34,7 +40,48 @@ func (s *store) GetBuild(id string) (*brigade.Build, error) {
 	return b, err
 }
 
-// Get creates a new project and writes it to storage.
+// DeleteBuild deletes a build.
+func (s *store) DeleteBuild(bid string, options storage.DeleteBuildOptions) error {
+	opts := meta.ListOptions{
+		LabelSelector: fmt.Sprintf(jobFilter, bid),
+	}
+	delOpts := meta.NewDeleteOptions(0)
+	pods, err := s.client.CoreV1().Pods(s.namespace).List(opts)
+	if err != nil {
+		return err
+	}
+	if options.SkipRunningBuilds {
+		for _, p := range pods.Items {
+			if p.Labels["component"] == "build" {
+				if p.Status.Phase == v1.PodRunning || p.Status.Phase == v1.PodPending {
+					return errors.New("skipping because build is still running")
+				}
+			}
+		}
+	}
+	for _, p := range pods.Items {
+		log.Printf("Deleting pod %q", p.Name)
+		if err := s.client.CoreV1().Pods(s.namespace).Delete(p.Name, delOpts); err != nil {
+			log.Printf("failed to delete job pod %s (continuing): %s", p.Name, err)
+		}
+	}
+
+	secrets, err := s.client.CoreV1().Secrets(s.namespace).List(opts)
+	if err != nil {
+		return err
+	}
+	for _, sec := range secrets.Items {
+		log.Printf("Deleting secret %q", sec.Name)
+		if err := s.client.CoreV1().Secrets(s.namespace).Delete(sec.Name, delOpts); err != nil {
+			log.Printf("failed to delete job secret %s (continuing): %s", sec.Name, err)
+		}
+	}
+
+	// As a safety condition, we might also consider deleting PVCs.
+	return nil
+}
+
+// CreateBuild creates a new Secret based on the build options and writes it to storage.
 func (s *store) CreateBuild(build *brigade.Build) error {
 	if build.ID == "" {
 		build.ID = genID()

--- a/pkg/storage/kube/build.go
+++ b/pkg/storage/kube/build.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -54,7 +53,8 @@ func (s *store) DeleteBuild(bid string, options storage.DeleteBuildOptions) erro
 		for _, p := range pods.Items {
 			if p.Labels["component"] == "build" {
 				if p.Status.Phase == v1.PodRunning || p.Status.Phase == v1.PodPending {
-					return errors.New("skipping because build is still running")
+					log.Printf("skipping Build %s because it is on Status %s", p.Labels["build"], p.Status.Phase)
+					return nil
 				}
 			}
 		}

--- a/pkg/storage/kube/build_test.go
+++ b/pkg/storage/kube/build_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/brigade/pkg/storage"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -43,6 +45,27 @@ func TestCreateBuild(t *testing.T) {
 	secrets, _ := k.CoreV1().Secrets("default").List(metav1.ListOptions{})
 	if len(secrets.Items) != 1 {
 		t.Fatalf("Build was not stored as secret")
+	}
+}
+
+func TestDeleteBuild(t *testing.T) {
+	k, s := fakeStore()
+	if err := s.CreateBuild(stubBuild); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, _ := k.CoreV1().Secrets("default").List(metav1.ListOptions{})
+	if len(secrets.Items) != 1 {
+		t.Fatalf("Build was not stored as secret")
+	}
+
+	if err := s.DeleteBuild(stubBuild.ID, storage.DeleteBuildOptions{SkipRunningBuilds: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	secrets, _ = k.CoreV1().Secrets("default").List(metav1.ListOptions{})
+	if len(secrets.Items) != 0 {
+		t.Fatalf("Build was not deleted")
 	}
 }
 

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/Azure/brigade/pkg/storage"
+
 	"github.com/Azure/brigade/pkg/brigade"
 )
 
@@ -179,6 +181,11 @@ func (s *Store) GetWorkerLogStreamFollow(w *brigade.Worker) (io.ReadCloser, erro
 // CreateBuild fakes a new build.
 func (s *Store) CreateBuild(b *brigade.Build) error {
 	s.Build = b
+	return nil
+}
+
+// DeleteBuild fakes a build deletion.
+func (s *Store) DeleteBuild(bid string, options storage.DeleteBuildOptions) error {
 	return nil
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -6,6 +6,11 @@ import (
 	"github.com/Azure/brigade/pkg/brigade"
 )
 
+// DeleteBuildOptions represents options for a build deletion
+type DeleteBuildOptions struct {
+	SkipRunningBuilds bool
+}
+
 // ProjectStore represents storage for projects.
 type ProjectStore interface {
 	// GetProjects retrieves all projects from storage.
@@ -27,6 +32,8 @@ type Store interface {
 	GetBuilds() ([]*brigade.Build, error)
 	// GetBuild retrieves the build from storage.
 	GetBuild(id string) (*brigade.Build, error)
+	// DeleteBuild deletes the build from storage.
+	DeleteBuild(id string, options DeleteBuildOptions) error
 	// CreateBuild creates a new job for the work queue.
 	CreateBuild(build *brigade.Build) error
 	// GetBuildJobs retrieves all build jobs (pods) from storage.


### PR DESCRIPTION
Implements #586 

Notes:
- `brig build delete` will delete the BuildID regardless of its state
- `brig build delete-all` will delete only non-running Builds from Project
- there was some code in vacuum about Build deletion - moved that to `pkg/storage/kube` so it can be used from both vacuum and brig

many thanks to @radu-matei for guidance and encouragement!