### PR TITLE
Modify vacuum.Run to not return the number of deleted builds

### DIFF
--- a/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
+++ b/brigade-vacuum/cmd/brigade-vacuum/commands/app.go
@@ -92,9 +92,7 @@ var Root = &cobra.Command{
 		if globalVerbose {
 			fmt.Fprintf(os.Stderr, "Max Age: %s\nMax Builds: %d\n", age, mb)
 		}
-		count, err := vacuum.New(age, mb, srb, c, ns()).Run()
-		fmt.Fprintf(os.Stdout, "Deleted %d\n", count)
-		return err
+		return vacuum.New(age, mb, srb, c, ns()).Run()
 	},
 }
 


### PR DESCRIPTION
As per discussion on #698

- modified vacuum.Run to not return the number of deleted builds. #695  modified deleteBuild behavior and this led to test inconsistencies
- refactored tests to explicitly check for deleted/existent pods
- the only downside is that vacuum execution now does not report the number of deleted builds. However, relevant deletion messages are logged through deleteBuild, so I guess there's not much harm in that