### PR TITLE
fix(charts/brigade): add legacy label in for upgrades

### DIFF
--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ template "brigade.fullname" . }}-api
+        app: {{ template "brigade.fullname" . }}-api
         role: api
     spec:
       serviceAccountName: {{ template "brigade.api.fullname" . }}

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: {{ $fullname }}
+        app: {{ $fullname }}
         role: controller
     spec:
       serviceAccountName: {{ $fullname }}


### PR DESCRIPTION
This avoids the following upgrade error due to the new label pattern introduced post-v0.18.0:
```
 $ helm upgrade brigade-server charts/brigade
Error: UPGRADE FAILED: Deployment.apps "brigade-server-brigade-api" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"role":"api", "app.kubernetes.io/name":"brigade-server-brigade-api"}: `selector` does not match template `labels` && Deployment.apps "brigade-server-brigade-ctrl" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"role":"controller", "app.kubernetes.io/name":"brigade-server-brigade-ctrl"}: `selector` does not match template `labels`
```