### PR TITLE
ref(Makefile): switch to golangci for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-js: bootstrap-js
 
 .PHONY: test-style
 test-style:
-	gometalinter --config ./gometalinter.json ./...
+	golangci-lint run --config ./golangci.yml
 
 .PHONY: test-chart
 test-chart:
@@ -130,7 +130,7 @@ format-go:
 format-js:
 	cd brigade-worker && yarn format
 
-HAS_GOMETALINTER := $(shell command -v gometalinter;)
+HAS_GOLANGCI     := $(shell command -v golangci-lint;)
 HAS_DEP          := $(shell command -v dep;)
 HAS_GIT          := $(shell command -v git;)
 HAS_YARN         := $(shell command -v yarn;)
@@ -149,9 +149,10 @@ endif
 ifndef HAS_DEP
 	go get -u github.com/golang/dep/cmd/dep
 endif
-ifndef HAS_GOMETALINTER
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
+ifndef HAS_GOLANGCI
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint && \
+	cd $(GOPATH)/src/github.com/golangci/golangci-lint/cmd/golangci-lint && \
+	go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
 endif
 	dep ensure
 

--- a/brigade.js
+++ b/brigade.js
@@ -31,6 +31,7 @@ function goTest(e, project) {
     // Need to move the source into GOPATH so vendor/ works as desired.
     "mkdir -p " + localPath,
     "mv /src/* " + localPath,
+    "mv /src/.git " + localPath,
     "cd " + localPath,
     "make vendor",
     "make test-style",

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,20 @@
+run:
+  deadline: 2m
+
+linters:
+  disable-all: true
+  enable:
+  - gofmt
+  - goimports
+  - golint
+  - gosimple
+  - ineffassign
+  - misspell
+  - unused
+  - deadcode
+  - govet
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/Azure/brigade
+  


### PR DESCRIPTION
We've had good success with [golangci-lint](https://github.com/golangci/golangci-lint) in other [projects](https://github.com/deislabs/duffle), so proposing the switch here as well.