### PR TITLE
fixed brig project create --replace

### DIFF
--- a/brig/cmd/brig/commands/project_create.go
+++ b/brig/cmd/brig/commands/project_create.go
@@ -153,16 +153,14 @@ func createProject(out io.Writer) error {
 	// brig project create --replace
 	if projectCreateReplace {
 		if _, err = store.GetProject(proj.ID); err != nil {
-			fmt.Printf("project %s could not be found (error: %s). Cannot replace, exiting\n", proj.Name, err.Error())
-			return nil
+			return fmt.Errorf("project %s could not be found (error: %s). Cannot replace, exiting", proj.Name, err.Error())
 		}
 		return store.ReplaceProject(proj)
 	}
 
 	// brig project create # no replace
 	if _, err = store.GetProject(proj.ID); err == nil {
-		fmt.Printf("project %s already exists. Refusing to overwrite\n", proj.Name)
-		return nil
+		return fmt.Errorf("project %s already exists. Refusing to overwrite", proj.Name)
 	}
 	// Store the project
 	return store.CreateProject(proj)

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -96,6 +96,24 @@ func (s *Store) CreateProject(p *brigade.Project) error {
 	return nil
 }
 
+// ReplaceProject replaces a project in the internal mock
+func (s *Store) ReplaceProject(p *brigade.Project) error {
+	found := false
+	for _, pr := range s.ProjectList {
+		if pr.Name == p.Name {
+			pr = p
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("Project with ID %s was not found", p.ID)
+	}
+
+	return nil
+}
+
 // DeleteProject deletes a project from the internal mock
 func (s *Store) DeleteProject(id string) error {
 	tmp := []*brigade.Project{}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -21,6 +21,8 @@ type ProjectStore interface {
 	GetProjectBuilds(proj *brigade.Project) ([]*brigade.Build, error)
 	// CreateProject creates a new project record in storage.
 	CreateProject(proj *brigade.Project) error
+	// ReplaceProject replaces a project record in storage.
+	ReplaceProject(proj *brigade.Project) error
 	// DeleteProject deletes a project from storage.
 	DeleteProject(id string) error
 }


### PR DESCRIPTION
Proposed fix for #667 

Need a second opinion [here](https://github.com/dgkanatsios/brigade/blob/fix/project-create-replace/brig/cmd/brig/commands/project_create.go#L157) and [here](https://github.com/dgkanatsios/brigade/blob/fix/project-create-replace/brig/cmd/brig/commands/project_create.go#L165)
If I return the errors themselves, cobra will display usage info, which should not happen. So, I'm returning nil error and displaying a message instead. Is this sufficient?