### PR TITLE
allow configuring the service account in the helm chart

### DIFF
--- a/charts/brigade/templates/api-deployment.yaml
+++ b/charts/brigade/templates/api-deployment.yaml
@@ -1,4 +1,6 @@
 {{ if .Values.api.enabled }}
+{{ $fullname := include "brigade.api.fullname" . }}
+{{ $serviceAccount := default $fullname .Values.api.serviceAccount.name }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -18,7 +20,7 @@ spec:
         app: {{ template "brigade.fullname" . }}-api
         role: api
     spec:
-      serviceAccountName: {{ template "brigade.api.fullname" . }}
+      serviceAccountName: {{ $serviceAccount }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.api.registry }}/{{ .Values.api.name }}:{{ default .Chart.AppVersion .Values.api.tag }}"

--- a/charts/brigade/templates/api-role.yaml
+++ b/charts/brigade/templates/api-role.yaml
@@ -1,15 +1,18 @@
 {{ if .Values.api.enabled }}
 {{ $fname := include "brigade.api.fullname" . }}
+{{ $serviceAccount := default $fname .Values.api.serviceAccount.name }}
+{{ if .Values.api.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "brigade.fullname" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{ end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role
@@ -37,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}

--- a/charts/brigade/templates/controller-deployment.yaml
+++ b/charts/brigade/templates/controller-deployment.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.controller.enabled }}{{ $fullname := include "brigade.ctrl.fullname" . }}
+{{ $serviceAccount := default $fullname .Values.controller.serviceAccount.name }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -18,7 +19,7 @@ spec:
         app: {{ $fullname }}
         role: controller
     spec:
-      serviceAccountName: {{ $fullname }}
+      serviceAccountName: {{ $serviceAccount }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.controller.registry }}/{{ .Values.controller.name }}:{{ default .Chart.AppVersion .Values.controller.tag }}"

--- a/charts/brigade/templates/controller-role.yaml
+++ b/charts/brigade/templates/controller-role.yaml
@@ -1,15 +1,18 @@
 {{ if .Values.controller.enabled }}
 {{ $fname := include "brigade.ctrl.fullname" . }}
+{{ $serviceAccount := default $fname .Values.controller.serviceAccount.name }}
+{{ if .Values.controller.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "brigade.fullname" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{ end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role
@@ -37,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}

--- a/charts/brigade/templates/gateway-cr-deployment.yaml
+++ b/charts/brigade/templates/gateway-cr-deployment.yaml
@@ -1,5 +1,6 @@
 {{ if .Values.cr.enabled }}
 {{ $fullname := include "brigade.cr.fullname" . }}
+{{ $serviceAccount := default $fullname .Values.cr.serviceAccount.name }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -20,7 +21,7 @@ spec:
         role: gateway
         type: dockerhub
     spec:
-      serviceAccountName: {{ $fullname }}
+      serviceAccountName: {{ $serviceAccount }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.cr.registry }}/{{ .Values.cr.name }}:{{ default .Chart.AppVersion .Values.cr.tag }}"

--- a/charts/brigade/templates/gateway-cr-role.yaml
+++ b/charts/brigade/templates/gateway-cr-role.yaml
@@ -1,15 +1,18 @@
 {{ if .Values.cr.enabled }}
 {{ $fname := include "brigade.cr.fullname" . }}
+{{ $serviceAccount := default $fname .Values.cr.serviceAccount.name }}
+{{ if .Values.cr.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "brigade.fullname" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{ end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role
@@ -37,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}

--- a/charts/brigade/templates/gateway-github-deployment.yaml
+++ b/charts/brigade/templates/gateway-github-deployment.yaml
@@ -1,5 +1,6 @@
 {{ if .Values.gw.enabled }}
 {{ $fullname := include "brigade.gw.fullname" . }}
+{{ $serviceAccount := default $fullname .Values.gw.serviceAccount.name }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -20,7 +21,7 @@ spec:
         role: gateway
         type: github
     spec:
-      serviceAccountName: {{ $fullname }}
+      serviceAccountName: {{ $serviceAccount }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.gw.registry }}/{{ .Values.gw.name }}:{{ default .Chart.AppVersion .Values.gw.tag }}"

--- a/charts/brigade/templates/gateway-github-role.yaml
+++ b/charts/brigade/templates/gateway-github-role.yaml
@@ -1,15 +1,18 @@
 {{ if .Values.gw.enabled }}
 {{ $fname := include "brigade.gw.fullname" . }}
+{{ $serviceAccount := default $fname .Values.gw.serviceAccount.name }}
+{{ if .Values.gw.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "brigade.fullname" . }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{ end }}
 {{ if .Values.rbac.enabled }}
 ---
 kind: Role
@@ -40,7 +43,7 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ $fname }}
+  name: {{ $serviceAccount }}
 roleRef:
   kind: Role
   name: {{ $fname }}

--- a/charts/brigade/values.yaml
+++ b/charts/brigade/values.yaml
@@ -50,6 +50,9 @@ controller:
   #  requests:
   #    cpu:
   #    memory:
+  serviceAccount:
+    create: true
+    name: 
 
 # api is the API server. It is technically not needed for the operation of the
 # Brigade controller, but it is used by tools to learn about the state of the
@@ -78,6 +81,9 @@ api:
     hosts: []
     paths:
     - /
+  serviceAccount:
+    create: true
+    name: 
 
 # worker is the JavaScript worker. These are created on demand by the controller.
 worker:
@@ -104,6 +110,9 @@ gw:
     - OWNER
     - MEMBER
     - COLLABORATOR
+  serviceAccount:
+    create: true
+    name: 
 
   # DEPRECATED: As of Brigade v0.10.0, this is a no-op. Use allowedAuthorRoles
   # isntead.
@@ -127,6 +136,9 @@ cr:
     type: ClusterIP  # Change to LoadBalancer if you want this externally available.
     externalPort: 80
     internalPort: 8000
+  serviceAccount:
+    create: true
+    name: 
 
 # The vacuum periodically cleans up old builds.
 # Brigade does not delete builds on completion. Instead, it leaves builds around


### PR DESCRIPTION
In my environment RBAC and service accounts cannot be created via helm so I have added the ability to not create the service accounts as well as set their name.