### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!--
+Thanks for filing an issue! If this is a question or feature request, just delete
+everything here and write out the request, providing as much context as you can.
+-->
+
+Output of `brig version`:
+
+Output of `kubectl version`:
+
+Cloud Provider/Platform (AKS, GKE, Minikube etc.):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thanks for sending a pull request!  Here are some tips for you:
+1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/Azure/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).
+
+2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.
+
+3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
+-->
+
+**What this PR does / why we need it**:
+
+**Special notes for your reviewer**:
+
+**If applicable**:
+- [ ] this PR contains documentation
+- [ ] this PR contains unit tests
+- [ ] this PR has been tested for backwards compatibility


### PR DESCRIPTION
This PR adds [GitHub issue and pull request templates](https://help.github.com/articles/setting-up-your-project-for-healthy-contributions/).

I've actually been going back and forth between multiple versions of the templates for a while now, and decided it is a good time for this to get some feedback, and it would be a great start of the year to improve the experience when contributing to this project.

The templates are a combination of the Helm templates (thanks @tariq1890 and Helm folks for reviewing them) and the `dep` templates.

Happy New Year! 🎉 