### PR TITLE
small docs refactor

### DIFF
--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -11,6 +11,7 @@ If you don't see a topic guide here and have a reasonable level of knowledge on 
 - Using Brigade (brigade.js, webhooks)
   - [Scripting Guide](scripting.md): How to write JavaScript for `brigade.js` files.
   - [Brigade.js Reference](javascript.md): The API for brigade.js files.
+  - [Scripting Guide - Advanced](scripting_advanced.md): Advanced examples for `brigade.js` files.
   - [GitHub Integration](github.md): A guide for configuring GitHub integration.
   - [Container Registry Integration](dockerhub.md): A guide for configuring integration with DockerHub or Azure Container Registry.
   - [Using Secrets](secrets.md): How to pass sensitive data into builds.
@@ -18,6 +19,8 @@ If you don't see a topic guide here and have a reasonable level of knowledge on 
 - Configuring and Running Brigade
   - [Projects](projects.md): Install, upgrade, and use Brigade Projects.
   - [Securing Brigade](security.md): Things to consider when configuring Brigade.
+  - [Storage](storage.md): How Brigade uses Kubernetes Persistent Storage
+  - [Workers](workers.md): More information regarding Brigade Worker
   - [Example Projects](../index.md#technical): Brigade-related projects
 - Contributing to Brigade Development
   - [Brigade Developers Guide](developers.md): A guide for people who want to modify Brigade's

--- a/docs/topics/scripting.md
+++ b/docs/topics/scripting.md
@@ -1329,6 +1329,6 @@ This particular feature can be useful when writing `after` and `error` handlers
 This guide covers the basics of working with `brigade.js` files. If you are not sure how to
 get started with Brigade now, you might want to take a look at the [tutorial](../intro). If
 you want more details about the Brigade JS API, you can look at the [API
-documentation](javascript.md).
+documentation](javascript.md). For a more advanced scripting guide, check [here](scripting_advanced.md).
 
 Happy Scripting!


### PR DESCRIPTION
As I was writing the doc for #721 noticed a couple of minor things that can be improved in the documentation

- first of all, scripting_advanced.md isn't linked from anywhere, so I added that on index
- same with storage.md
- workers.md is only mentioned on scripting.md and could get some love by getting an index link as well

WDYT?