### PR TITLE
add the ability to toggle usage of secretKeyRef in jobs

### DIFF
--- a/brig/cmd/brig/commands/project_create.go
+++ b/brig/cmd/brig/commands/project_create.go
@@ -377,6 +377,14 @@ func projectAdvancedPrompts(p *brigade.Project) error {
 				Default: p.Kubernetes.CacheStorageClass,
 			},
 		},
+		{
+			Name: "allowSecretKeyRef",
+			Prompt: &survey.Confirm{
+				Message: "SecretKeyRef usage",
+				Help:    "Allow or disallow usage of secretKeyRef in job environments.",
+				Default: p.Kubernetes.AllowSecretKeyRef,
+			},
+		},
 	}, &p.Kubernetes); err != nil {
 		return fmt.Errorf(abort, err)
 	}

--- a/brigade-controller/cmd/brigade-controller/controller/controller_test.go
+++ b/brigade-controller/cmd/brigade-controller/controller/controller_test.go
@@ -13,6 +13,8 @@ import (
 	core "k8s.io/client-go/testing"
 )
 
+const expectedEnvironmentLength = 16
+
 func TestController(t *testing.T) {
 	createdPod := false
 	client := fake.NewSimpleClientset()
@@ -94,8 +96,8 @@ func TestController(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 15 {
-		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != expectedEnvironmentLength {
+		t.Errorf("expected %d items in Container.Env, got %d", expectedEnvironmentLength, envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -127,8 +129,8 @@ func TestController(t *testing.T) {
 		t.Fatalf("Expected 1 init container, got %d", l)
 	}
 	ic := pod.Spec.InitContainers[0]
-	if envlen := len(ic.Env); envlen != 15 {
-		t.Errorf("expected 15 env vars, got %d", envlen)
+	if envlen := len(ic.Env); envlen != expectedEnvironmentLength {
+		t.Errorf("expected %d env vars, got %d", expectedEnvironmentLength, envlen)
 	}
 
 	if ic.Image != sidecarImage {
@@ -233,8 +235,8 @@ func TestController_WithScript(t *testing.T) {
 	if c.Name != "brigade-runner" {
 		t.Error("Container.Name is not correct")
 	}
-	if envlen := len(c.Env); envlen != 15 {
-		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != expectedEnvironmentLength {
+		t.Errorf("expected %d items in Container.Env, got %d", expectedEnvironmentLength, envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -309,8 +311,8 @@ func TestController_NoSidecar(t *testing.T) {
 	}
 
 	c := pod.Spec.Containers[0]
-	if envlen := len(c.Env); envlen != 15 {
-		t.Errorf("expected 15 items in Container.Env, got %d", envlen)
+	if envlen := len(c.Env); envlen != expectedEnvironmentLength {
+		t.Errorf("expected %d items in Container.Env, got %d", expectedEnvironmentLength, envlen)
 	}
 	if c.Image != config.WorkerImage {
 		t.Error("Container.Image is not correct")
@@ -538,8 +540,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 			if c.Name != "brigade-runner" {
 				t.Error("Container.Name is not correct")
 			}
-			if envlen := len(c.Env); envlen != 15 {
-				t.Errorf("expected 15 items in Container.Env, got %d", envlen)
+			if envlen := len(c.Env); envlen != expectedEnvironmentLength {
+				t.Errorf("expected %d items in Container.Env, got %d", expectedEnvironmentLength, envlen)
 			}
 			if c.Image != test.expWorkerImage {
 				t.Errorf("Container.Image is not correct, got %s; want %s", c.Image, test.expWorkerImage)
@@ -555,8 +557,8 @@ func TestController_WithProjectSpecificWorkerConfig(t *testing.T) {
 				t.Fatalf("Expected 1 init container, got %d", l)
 			}
 			ic := pod.Spec.InitContainers[0]
-			if envlen := len(ic.Env); envlen != 15 {
-				t.Errorf("expected 15 env vars, got %d", envlen)
+			if envlen := len(ic.Env); envlen != expectedEnvironmentLength {
+				t.Errorf("expected %d env vars, got %d", expectedEnvironmentLength, envlen)
 			}
 
 			if ic.Image != sidecarImage {

--- a/brigade-worker/src/brigadier.ts
+++ b/brigade-worker/src/brigadier.ts
@@ -52,7 +52,7 @@ export class Job extends jobImpl.Job {
   jr: JobRunner;
 
   run(): Promise<jobImpl.Result> {
-    this.jr = new JobRunner().init(this, currentEvent, currentProject);
+    this.jr = new JobRunner().init(this, currentEvent, currentProject, process.env.BRIGADE_SECRET_KEY_REF == 'true');
     this._podName = this.jr.name;
     return this.jr.run().catch(err => {
       // Wrap the message to give clear context.

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -246,8 +246,9 @@ export class JobRunner implements jobs.JobRunner {
    * @param job The Job object
    * @param e  The event that was fired
    * @param project  The project in which this job runs
+   * @param allowSecretKeyRef  Allow secretKeyRef in the job's environment
    */
-  public init<T extends jobs.Job>(job: T, e: BrigadeEvent, project: Project) {
+  public init<T extends jobs.Job>(job: T, e: BrigadeEvent, project: Project, allowSecretKeyRef: boolean = true) {
     this.options = Object.assign({}, options);
     this.event = e;
     this.logger = new ContextLogger("k8s", e.logLevel);
@@ -318,6 +319,11 @@ export class JobRunner implements jobs.JobRunner {
       } else {
         // For environmental variables that are directly references,
         // add the reference to the env var list.
+
+        if (val.secretKeyRef != null && !allowSecretKeyRef) {
+         // allowSecretKeyRef is not to true so disallow setting secrets in the environment
+         continue
+        }
 
         envVars.push({
           name: key,

--- a/brigade-worker/src/k8s.ts
+++ b/brigade-worker/src/k8s.ts
@@ -322,6 +322,7 @@ export class JobRunner implements jobs.JobRunner {
 
         if (val.secretKeyRef != null && !allowSecretKeyRef) {
          // allowSecretKeyRef is not to true so disallow setting secrets in the environment
+         this.logger.warn(`Using secretKeyRef is not allowed in this project, not setting environment variable ${key}`);
          continue
         }
 

--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -147,6 +147,38 @@ describe("k8s", function() {
             assert.equal(found, 2);
           });
         });
+        context("as references with allowSecretKeyRef false", function() {
+          beforeEach(function() {
+            j.env = {
+              one: {
+                secretKeyRef: {
+                  name: "secret-name",
+                  key: "secret-key"
+                }
+              } as kubernetes.V1EnvVarSource,
+              two: {
+                configMapKeyRef: {
+                  name: "configmap-name",
+                  key: "configmap-key"
+                }
+              } as kubernetes.V1EnvVarSource
+            };
+          });
+          it("sets them on the pod", function() {
+            let jr = new k8s.JobRunner().init(j, e, p, false);
+            let found = 0;
+
+            for (let k in j.env) {
+              for (let env of jr.runner.spec.containers[0].env) {
+                if (env.name == k) {
+                  assert.equal(env.valueFrom, j.env[k]);
+                  found++;
+                }
+              }
+            }
+            assert.equal(found, 1);
+          });
+        });
       });
       context("when resources are specified", function() {
         beforeEach(function() {

--- a/pkg/brigade/project.go
+++ b/pkg/brigade/project.go
@@ -117,4 +117,6 @@ type Kubernetes struct {
 	BuildStorageClass string `json:"buildStorageClass"`
 	// CacheStorageClass is the storage class used for caching jobs.
 	CacheStorageClass string `json:"cacheStorageClass"`
+	// AllowSecretKeyRef controls if secretKeyRefs can be used in the job's environment
+	AllowSecretKeyRef bool `json:"allowSecretKeyRef"`
 }

--- a/pkg/storage/kube/project.go
+++ b/pkg/storage/kube/project.go
@@ -9,6 +9,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"strconv"
+
 	"github.com/Azure/brigade/pkg/brigade"
 )
 
@@ -102,6 +104,7 @@ func SecretFromProject(project *brigade.Project) (v1.Secret, error) {
 
 			"kubernetes.cacheStorageClass": project.Kubernetes.CacheStorageClass,
 			"kubernetes.buildStorageClass": project.Kubernetes.BuildStorageClass,
+			"kubernetes.allowSecretKeyRef": strconv.FormatBool(project.Kubernetes.AllowSecretKeyRef),
 		},
 	}
 	return secret, nil
@@ -174,6 +177,14 @@ func NewProjectFromSecret(secret *v1.Secret, namespace string) (*brigade.Project
 	proj.Kubernetes.BuildStorageSize = def(sv.String("buildStorageSize"), "50Mi")
 	proj.Kubernetes.BuildStorageClass = sv.String("kubernetes.buildStorageClass")
 	proj.Kubernetes.CacheStorageClass = sv.String("kubernetes.cacheStorageClass")
+
+	if sv.String("kubernetes.allowSecretKeyRef") != "" {
+		if allowSecretKeyRef, err := strconv.ParseBool(sv.String("kubernetes.allowSecretKeyRef")); err == nil {
+			proj.Kubernetes.AllowSecretKeyRef = allowSecretKeyRef
+		} else {
+			return nil, fmt.Errorf("error parsing 'kubernetes.allowSecretKeyRef': %s", err.Error())
+		}
+	}
 
 	proj.DefaultScript = sv.String("defaultScript")
 	proj.DefaultScriptName = sv.String("defaultScriptName")


### PR DESCRIPTION
**What this PR does / why we need it**: Adds the ability to toggle usage of `secretKeyRef` in jobs. Fixes #750 

I am not too familiar with javascript so I am not sure if this is the correct way to do it.
