### PR TITLE
Use the job shell when starting the container

### DIFF
--- a/brigade-worker/test/k8s.ts
+++ b/brigade-worker/test/k8s.ts
@@ -508,6 +508,21 @@ describe("k8s", function() {
           );
         });
       });
+      context("when no job shell is specified", function() {
+        it("default shell is /bin/sh", function() {
+          let jr = new k8s.JobRunner().init(j, e, p);
+          assert.deepEqual(jr.runner.spec.containers[0].command, [ '/bin/sh', '/hook/main.sh' ]);
+        });
+      });
+      context("when job shell is specified", function() {
+        beforeEach(function() {
+          j.shell = "/bin/bash"
+        });
+        it("shell is /bin/bash", function() {
+          let jr = new k8s.JobRunner().init(j, e, p);
+          assert.deepEqual(jr.runner.spec.containers[0].command, [ '/bin/bash', '/hook/main.sh' ]);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR uses the provided `job.shell` when defining the job command (description in #756)

**Special notes for your reviewer**: 
To test this, update the controller environment variable that defines what worker should be started, then test with the following `brigade.js` file:

```
const { events, Job } = require("brigadier")

events.on("exec", () => {
  var sh = new Job("sh", "ubuntu:latest")
  sh.shell = "/bin/sh"
  sh.tasks = ["ps ax"];

  var bash = new Job("bash", "ubuntu:latest")
  bash.shell = "/bin/bash"
  bash.tasks = ["ps ax"];

  sh.run()
  bash.run()
});
```

You should see the correct shells being started in the logs of the pods:

```
$ kubectl logs sh-01d0n5ad7warya7xthg9tda4w2
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /bin/sh /hook/main.sh
    6 ?        R      0:00 ps ax
radu:~$ kubectl logs bash-01d0n5ad7warya7xthg9tda4w2
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /bin/bash /hook/main.sh
    6 ?        R      0:00 ps ax
```

closes #756 