### PR TITLE
fix LastBuild in ProjectBuildSummary

### DIFF
--- a/pkg/api/project_test.go
+++ b/pkg/api/project_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/Azure/brigade/pkg/storage/mock"
+)
+
+func TestGetBuildSummariesForProjects(t *testing.T) {
+	project := &Project{
+		store: mock.New(),
+	}
+
+	projects, err := project.store.GetProjects()
+	if err != nil {
+		t.Fatalf("error: %s", err.Error())
+	}
+	projectSummaries := project.getBuildSummariesForProjects(projects)
+
+	if projectSummaries[0].LastBuild.ID != "build-id1" {
+		t.Fatal("wrong BuildID in getBuildSummariesForProjects")
+	}
+}

--- a/pkg/storage/mock/storage.go
+++ b/pkg/storage/mock/storage.go
@@ -21,28 +21,51 @@ var (
 		SharedSecret: "shared-secre3t",
 		Secrets:      map[string]string{"key": "value"},
 	}
-	// StubWorker is a stub Worker. It is used in StubBuild, too.
-	StubWorker = &brigade.Worker{
-		ID:        "worker-id",
-		BuildID:   "build-id",
+	// StubWorker1 is a stub Worker. It is used in StubBuild1, too.
+	StubWorker1 = &brigade.Worker{
+		ID:        "worker-id1",
+		BuildID:   "build-id1",
 		ProjectID: "project-id",
 		StartTime: Now,
 		EndTime:   Now,
 		ExitCode:  0,
 		Status:    brigade.JobSucceeded,
 	}
-	// StubBuild is a stub Build.
-	StubBuild = &brigade.Build{
-		ID:        "build-id",
+	// StubWorker2 is a stub Worker. It is used in StubBuild2, too.
+	StubWorker2 = &brigade.Worker{
+		ID:        "worker-id2",
+		BuildID:   "build-id2",
+		ProjectID: "project-id",
+		StartTime: Now.AddDate(0, 0, -1),
+		EndTime:   Now,
+		ExitCode:  0,
+		Status:    brigade.JobSucceeded,
+	}
+	// StubBuild1 is a stub Build.
+	StubBuild1 = &brigade.Build{
+		ID:        "build-id1", // do not change this as it's used in LastBuild related tests on Brigade API
 		ProjectID: "project-id",
 		Revision: &brigade.Revision{
-			Commit: "commit",
+			Commit: "commit1",
 		},
 		Type:     "type",
 		Provider: "provider",
 		Payload:  []byte("payload"),
 		Script:   []byte("script"),
-		Worker:   StubWorker,
+		Worker:   StubWorker1,
+	}
+	// StubBuild2 is another stub Build.
+	StubBuild2 = &brigade.Build{
+		ID:        "build-id2",
+		ProjectID: "project-id",
+		Revision: &brigade.Revision{
+			Commit: "commit2",
+		},
+		Type:     "type",
+		Provider: "provider",
+		Payload:  []byte("payload"),
+		Script:   []byte("script"),
+		Worker:   StubWorker2,
 	}
 	// StubJob is a stub Job.
 	StubJob = &brigade.Job{
@@ -63,8 +86,8 @@ var (
 func New() *Store {
 	return &Store{
 		ProjectList: []*brigade.Project{StubProject},
-		Worker:      StubWorker,
-		Build:       StubBuild,
+		Workers:     []*brigade.Worker{StubWorker1, StubWorker2},
+		Builds:      []*brigade.Build{StubBuild1, StubBuild2},
 		Job:         StubJob,
 		LogData:     StubLogData,
 	}
@@ -72,12 +95,12 @@ func New() *Store {
 
 // Store implements the storage.Storage interface, but returns mock data.
 type Store struct {
-	// Build is the build you want returned.
-	Build *brigade.Build
+	// Builds is a slice of Builds.
+	Builds []*brigade.Build
 	// Job is the job you want returned.
 	Job *brigade.Job
-	// Worker is the worker you want returned.
-	Worker *brigade.Worker
+	// Workers is a slice of workers.
+	Workers []*brigade.Worker
 	// LogData is the log data you want returned.
 	LogData string
 	// ProjectList on this mock
@@ -142,12 +165,12 @@ func (s *Store) GetProjectBuilds(p *brigade.Project) ([]*brigade.Build, error) {
 
 // GetBuilds returns the mock build wrapped in a slice.
 func (s *Store) GetBuilds() ([]*brigade.Build, error) {
-	return []*brigade.Build{s.Build}, nil
+	return s.Builds, nil
 }
 
-// GetBuild gets the mock Build.
+// GetBuild gets the first mock Build.
 func (s *Store) GetBuild(id string) (*brigade.Build, error) {
-	return s.Build, nil
+	return s.Builds[0], nil
 }
 
 // GetBuildJobs gets the mock job wrapped in a slice.
@@ -155,9 +178,9 @@ func (s *Store) GetBuildJobs(b *brigade.Build) ([]*brigade.Job, error) {
 	return []*brigade.Job{s.Job}, nil
 }
 
-// GetWorker gets the mock worker.
+// GetWorker gets the first mock worker.
 func (s *Store) GetWorker(bid string) (*brigade.Worker, error) {
-	return s.Worker, nil
+	return s.Workers[0], nil
 }
 
 // GetJob gets the mock job.
@@ -197,7 +220,7 @@ func (s *Store) GetWorkerLogStreamFollow(w *brigade.Worker) (io.ReadCloser, erro
 
 // CreateBuild fakes a new build.
 func (s *Store) CreateBuild(b *brigade.Build) error {
-	s.Build = b
+	s.Builds[0] = b
 	return nil
 }
 

--- a/pkg/storage/mock/storage_test.go
+++ b/pkg/storage/mock/storage_test.go
@@ -21,8 +21,8 @@ func TestStore(t *testing.T) {
 		}
 	}
 	assertSame("project", StubProject, m.ProjectList[0])
-	assertSame("worker", StubWorker, m.Worker)
-	assertSame("build", StubBuild, m.Build)
+	assertSame("worker", StubWorker1, m.Workers[0])
+	assertSame("builds", StubBuild1, m.Builds[0])
 	assertSame("job", StubJob, m.Job)
 	assertSame("log data", StubLogData, m.LogData)
 
@@ -34,22 +34,22 @@ func TestStore(t *testing.T) {
 	assertSame("GetProject", StubProject, extraProj)
 
 	b1, _ := m.GetProjectBuilds(StubProject)
-	assertSame("GetProjectBuilds", StubBuild, b1[0])
+	assertSame("GetProjectBuilds", StubBuild1, b1[0])
 
 	b2, _ := m.GetBuilds()
-	assertSame("GetBuilds", StubBuild, b2[0])
+	assertSame("GetBuilds", StubBuild1, b2[0])
 
-	b3, _ := m.GetBuild(StubBuild.ID)
-	assertSame("GetBuild", StubBuild, b3)
+	b3, _ := m.GetBuild(StubBuild1.ID)
+	assertSame("GetBuild", StubBuild1, b3)
 
-	j1, _ := m.GetBuildJobs(StubBuild)
+	j1, _ := m.GetBuildJobs(StubBuild1)
 	assertSame("GetBuildJobs", StubJob, j1[0])
 
 	j2, _ := m.GetJob(StubJob.ID)
 	assertSame("GetJob", StubJob, j2)
 
-	w1, _ := m.GetWorker(StubBuild.ID)
-	assertSame("GetWorker", StubWorker, w1)
+	w1, _ := m.GetWorker(StubBuild1.ID)
+	assertSame("GetWorker", StubWorker1, w1)
 
 	jl, _ := m.GetJobLog(StubJob)
 	assertSame("GetJobLog", StubLogData, jl)
@@ -64,15 +64,15 @@ func TestStore(t *testing.T) {
 	bjlsf.ReadFrom(jlsf)
 	assertSame("GetJobLogStreamFollow", StubLogData, bjlsf.String())
 
-	wl, _ := m.GetWorkerLog(StubWorker)
+	wl, _ := m.GetWorkerLog(StubWorker1)
 	assertSame("GetWorkerLog", StubLogData, wl)
 
-	wls, _ := m.GetWorkerLogStream(StubWorker)
+	wls, _ := m.GetWorkerLogStream(StubWorker1)
 	bwls := new(bytes.Buffer)
 	bwls.ReadFrom(wls)
 	assertSame("GetWorkerLogStream", StubLogData, bwls.String())
 
-	wlsf, _ := m.GetWorkerLogStreamFollow(StubWorker)
+	wlsf, _ := m.GetWorkerLogStreamFollow(StubWorker1)
 	bwlsf := new(bytes.Buffer)
 	bwlsf.ReadFrom(wlsf)
 	assertSame("GetWorkerLogStreamFollow", StubLogData, bwlsf.String())


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #780 

Currently ProjectBuildSummary does not contain the last Build from a chronological perspective but the last item return by K8s API Server. This PR sorts the returned slice by Worker.StartTime in order to fix that.

- [x] this PR contains unit tests

I had to modify existing mock code and tests in order to be able to test correct Build sorting.