### PR TITLE
docs(*): add releasing.md doc, bump strings in anticipation of v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ You will now have Brigade installed. [Kashti](https://github.com/Azure/kashti), 
 
 ### Install brig
 
-Brig is the Brigade command line client. You can use `brig` to create/update/delete new brigade Projects, run Builds, etc. To get `brig`, navigate to the [Releases page](https://github.com/Azure/brigade/releases/) and then download the appropriate client for your platform. For example, if you're using Linux or WSL, you can get the 0.19.0 version in this way:
+Brig is the Brigade command line client. You can use `brig` to create/update/delete new brigade Projects, run Builds, etc. To get `brig`, navigate to the [Releases page](https://github.com/Azure/brigade/releases/) and then download the appropriate client for your platform. For example, if you're using Linux or WSL, you can get the 0.20.0 version in this way:
 
 ```bash
-wget -O brig https://github.com/Azure/brigade/releases/download/v0.19.0/brig-linux-amd64
+wget -O brig https://github.com/Azure/brigade/releases/download/v0.20.0/brig-linux-amd64
 chmod +x brig
 mv brig ~/bin
 ``` 
@@ -136,7 +136,7 @@ Event created. Waiting for worker pod named "brigade-worker-01d0y7bcxs6ke0yayrx6
 Build: 01d0y7bcxs6ke0yayrx6nbvm39, Worker: brigade-worker-01d0y7bcxs6ke0yayrx6nbvm39
 prestart: no dependencies file found
 prestart: loading script from /etc/brigade/script
-[brigade] brigade-worker version: 0.19.0
+[brigade] brigade-worker version: 0.20.0
 [brigade:k8s] Creating secret do-nothing-01d0y7bcxs6ke0yayrx6nbvm39
 [brigade:k8s] Creating pod do-nothing-01d0y7bcxs6ke0yayrx6nbvm39
 [brigade:k8s] Timeout set at 900000

--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brigade-worker",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Brigade Worker",
   "main": "dist/index",
   "types": "dist/index",

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,10 @@ writing advanced Brigade scripts.
 
 [Dive deep into what makes Brigade, Brigade](topics/index.md).
 
+## Releasing Brigade
+
+For maintainers of this project, steps on cutting a new release of Brigade can be found [here](topics/releasing.md).
+
 ## Related Resources
 
 If you'd like to add links to this list, open a pull request on 

--- a/docs/topics/developers.md
+++ b/docs/topics/developers.md
@@ -41,7 +41,7 @@ cd $GOPATH/src/github.com/Azure/brigade
 **Note**: this leaves you at the tip of **master** in the repository where active development
 is happening. You might prefer to checkout the most recent stable tag:
 
-- `$ git checkout v0.19.0`
+- `$ git checkout v0.20.0`
 
 After cloning the project locally, you should run this command to [configure the remote](https://help.github.com/articles/configuring-a-remote-for-a-fork/): 
 
@@ -125,7 +125,7 @@ $ eval $(minikube docker-env)
 
 Running `make docker-build` will push the Brigade images to the Minikube Docker
 daemon. The image tag (set by `VERSION` in the [Makefile](../../Makefile)) will default
-to a unique value such as `v0.19.0-80-g6721dd8`.  You can verify this by running `docker images`
+to a unique value such as `v0.20.0-80-g6721dd8`.  You can verify this by running `docker images`
 and affirming these tagged images are listed.
 
 Brigade charts are hosted in the separate [Azure/brigade-charts][brigade-charts]

--- a/docs/topics/projects.md
+++ b/docs/topics/projects.md
@@ -89,7 +89,7 @@ The Brigade Project chart is located in the [Azure/brigade-charts][brigade-chart
 $ helm repo add brigade https://azure.github.io/brigade-charts
 $ helm search brigade/brigade-project
 NAME                   	CHART VERSION	APP VERSION	DESCRIPTION
-brigade/brigade-project	0.19.0       	v0.19.0    	Create a Brigade project
+brigade/brigade-project	0.20.0       	v0.20.0    	Create a Brigade project
 ```
 
 ### Creating and Managing a Project (The Old Way)

--- a/docs/topics/releasing.md
+++ b/docs/topics/releasing.md
@@ -1,0 +1,36 @@
+# Releasing Brigade
+
+Once the intended commit has been tested and we have confidence to cut a release,
+we can follow these steps to release Brigade:
+
+1. Issue a docs pull request with all `<current release>` strings updated to 
+`<anticipated release>`, e.g. `0.19.0` becomes `0.20.0`.
+
+    _(Note: amending [docs/index.yaml](../index.yaml) is not required.  This file still exists (as of writing)
+    only to serve older chart versions for a period of time after the chart migration to
+    [Azure/brigade-charts][brigade-charts] completed.)_
+
+1. Once this pull request is merged, create and push the git tag from the intended commit:
+
+    ```console
+    $ git tag v0.20.0
+    $ git push origin v0.20.0
+    ```
+
+    The release pipeline located in our [brigade.js](../../brigade.js) then takes over
+    and does the heavy lifting of building component images, pushing to designated
+    image registries, building the `brig` cli binaries and finally creating the
+    [GitHub release](https://github.com/Azure/brigade/releases).
+
+1. Lastly, issue a pull request in [Azure/brigade-charts][brigade-charts]
+bumping the `version` and `appVersion` values in the Brigade
+[chart](https://github.com/Azure/brigade-charts/blob/master/charts/brigade/Chart.yaml) and then
+re-building and re-indexing the charts.
+
+    ```console
+    $ # bump version and appVersion in charts/brigade/Chart.yaml
+    $ make build index
+    $ # commit changes, issue PR
+    ```
+
+[brigade-charts]: https://github.com/Azure/brigade-charts


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a releasing doc.
Bumps release strings in docs in anticipation of next `v0.20.0` release.
