### PR TITLE
[docs] mention that Generic Gateway supports only GitHub 

### DIFF
--- a/docs/topics/genericgateway.md
+++ b/docs/topics/genericgateway.md
@@ -1,6 +1,6 @@
 # Generic Gateway
 
-Brigade contains a Generic Gateway that can be used to accept requests from other platforms or systems. Generic Gateway is a separate component in the Brigade system, like Github and Container Registry (CR) Gateways.
+Brigade contains a Generic Gateway that can be used to accept requests from other platforms or systems. Generic Gateway is a separate component in the Brigade system, like Github and Container Registry (CR) Gateways. For the time being, Generic Gateway supports triggering Builds in Projects that have been configured with a `GitHub` repo. Support for additional Version Control Systems will come in future releases.
 
 Generic Gateway is _not enabled by default_.
 


### PR DESCRIPTION
As per #804, we should mention that the only VCS currently supported by Generic Gateway is GitHub, for the time being.

- [X] this PR contains documentation
