### PR TITLE
StartTime instead of EndTime on `brig build list` AGE column

### DIFF
--- a/brig/cmd/brig/commands/build_list.go
+++ b/brig/cmd/brig/commands/build_list.go
@@ -109,7 +109,7 @@ func getBuilds(project string, client kubernetes.Interface, count int) ([]*build
 		if b.Worker != nil {
 			bfs.status = b.Worker.Status.String()
 			if b.Worker.Status == brigade.JobSucceeded || b.Worker.Status == brigade.JobFailed {
-				bfs.since = duration.ShortHumanDuration(time.Since(b.Worker.EndTime))
+				bfs.since = duration.ShortHumanDuration(time.Since(b.Worker.StartTime))
 			}
 		}
 		bfss = append(bfss, bfs)

--- a/brig/cmd/brig/commands/build_list_test.go
+++ b/brig/cmd/brig/commands/build_list_test.go
@@ -66,10 +66,10 @@ func TestGetBuildList(t *testing.T) {
 	if bls[0].since != "???" || bls[0].ID != stubBuild2ID {
 		t.Error("Error in build2 time")
 	}
-	if bls[1].since != "1m" || bls[1].ID != stubBuild3ID {
+	if bls[1].since != "3m" || bls[1].ID != stubBuild3ID {
 		t.Error("Error in build3 time")
 	}
-	if bls[2].since != "2m" || bls[2].ID != stubBuild1ID {
+	if bls[2].since != "5m" || bls[2].ID != stubBuild1ID {
 		t.Error("Error in build1 time")
 	}
 }
@@ -90,7 +90,7 @@ func TestGetBuildListWithProject(t *testing.T) {
 	if bls[0].since != "???" || bls[0].ID != stubBuild2ID {
 		t.Error("Error in build2")
 	}
-	if bls[1].since != "2m" || bls[1].ID != stubBuild1ID {
+	if bls[1].since != "5m" || bls[1].ID != stubBuild1ID {
 		t.Error("Error in build1")
 	}
 
@@ -112,7 +112,7 @@ func TestGetBuildListCountTwo(t *testing.T) {
 	if bls[0].since != "???" || bls[0].ID != stubBuild2ID {
 		t.Error("Error in build2 time")
 	}
-	if bls[1].since != "1m" || bls[1].ID != stubBuild3ID {
+	if bls[1].since != "3m" || bls[1].ID != stubBuild3ID {
 		t.Error("Error in build3 time")
 	}
 


### PR DESCRIPTION
Fixes #810 

**What this PR does / why we need it**:
`brig build list` used Pod EndTime to display `Age` of the build. This was an error because
- Failed Pods are not assigned a correct EndTime, so value displayed was way off
- `Age` should report the birth time of the Pod (i.e. StartTime)


- [X] this PR contains unit tests
