### PR TITLE
Fix service account regex test

### DIFF
--- a/brigade-worker/package.json
+++ b/brigade-worker/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.7.2",
-    "@azure/brigadier": "^0.2.1",
+    "@azure/brigadier": "^0.4.0",
     "child-process-promise": "^2.2.1",
     "pretty-error": "^2.1.1",
     "ulid": "^0.2.0"

--- a/brigade-worker/src/index.ts
+++ b/brigade-worker/src/index.ts
@@ -78,8 +78,9 @@ if (process.env.BRIGADE_SERVICE_ACCOUNT) {
 }
 
 if (process.env.BRIGADE_SERVICE_ACCOUNT_REGEX) {
-  if (!options.serviceAccount.match(`${process.env.BRIGADE_SERVICE_ACCOUNT_REGEX}`)) {
-      logger.log(`Service Account ${options.serviceAccount} does not match regex /${process.env.BRIGADE_SERVICE_ACCOUNT_REGEX}/`);
+  let regex = RegExp(`${process.env.BRIGADE_SERVICE_ACCOUNT_REGEX}`);
+  if (!regex.test(options.serviceAccount)) {
+      logger.log(`Service Account ${options.serviceAccount} does not match regex ${process.env.BRIGADE_SERVICE_ACCOUNT_REGEX}`);
       process.exit(1);
   }
 }

--- a/brigade-worker/yarn.lock
+++ b/brigade-worker/yarn.lock
@@ -2,9 +2,10 @@
 # yarn lockfile v1
 
 
-"@azure/brigadier@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@azure/brigadier/-/brigadier-0.2.1.tgz#f1e38e6764e97d3ae53965f4947bb008b1d262e0"
+"@azure/brigadier@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/brigadier/-/brigadier-0.4.0.tgz#6fa24b6fc2dd85ae8a81f1b2cf57c7604597cf5d"
+  integrity sha512-ApMy7Pcu7+XDJS/2oTS1hpjCgYGNAXRdBubSpX0uipsv5sA8Drj7aB7Q/7EZUxpLmETgI4ZxQs/4l7Bm6c4qZQ==
   dependencies:
     "@kubernetes/client-node" "^0.7.2"
     child-process-promise "^2.2.1"


### PR DESCRIPTION
This PR updates the service account regex check to use `RegExp.test` instead of `string.match`, and updates Brigadier to the latest version, v0.3.

Now the questions I've been going around for the last couple of days for this PR:

- whether the job object should actually expose the service account regex - I don't think it should ever be updated by `brigade.js`.
- would it be used elsewhere in the worker?

cc @vdice, @rmb938 