### PR TITLE
Add CODEOWNERS file as a record of core maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# This file is described here:  https://help.github.com/en/articles/about-code-owners
+
+# Global Owners: These members are Core Maintainers of Brigade
+* @technosophos @adamreese @mumoshu @vdice @radu-matei
+
+# Specific responsibilities
+brigade-controller/ @adamreese
+Makefile @adamreese
+/brigade.js @vdice


### PR DESCRIPTION
This adds the CODEOWNERS file, which elaborates on who the core maintainers are, and also which people hold specific responsibilities.

For example, a change to `/brigade.js` ought to be reviewed by @vdice before being merged.

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR (https://github.com/Azure/brigade/blob/master/docs/topics/developers.md) and that your contribution follows our Code of Conduct (https://opensource.microsoft.com/codeofconduct/).

2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.

3. Work-in-progress PRs are welcome as a way to get early feedback - just prefix the title with [WIP].
-->

**What this PR does / why we need it**:

This adds a `CODEOWNERS` file to track ownership of (a) the code as a whole, and (b) specific parts of the codebase.

**Special notes for your reviewer**:

Related docs:
https://help.github.com/en/articles/about-code-owners

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
